### PR TITLE
Reduce number of MQTT command

### DIFF
--- a/Home_Assistant/automations/HASwitchPlatePages.yaml
+++ b/Home_Assistant/automations/HASwitchPlatePages.yaml
@@ -243,10 +243,6 @@
 
 ##############################################################################
 # Set page button colors across selected pages to show active page button
-# First we'll reset all page buttons, then overwrite our three pages with 
-# a highlighted page button to show the selection. 
-
-# set page button 1 colors on page 
 - alias: HASwitchPlate_PageButton_Colors
   trigger:
   - platform: state
@@ -255,6 +251,8 @@
     entity_id: input_number.haswitchplate_pagebutton2_page
   - platform: state
     entity_id: input_number.haswitchplate_pagebutton3_page
+  - platform: state
+    entity_id: input_number.haswitchplate_active_page
   - platform: mqtt
     topic: 'homeassistant/binary_sensor/HASwitchPlate/state'
     payload: 'ON'
@@ -262,243 +260,56 @@
     event: start
   action:
   - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[1].b[1].bco'
-      payload: '25388'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[1].b[1].pco'
-      payload: '65535'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[1].b[2].bco'
-      payload: '25388'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[1].b[2].pco'
-      payload: '65535'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[1].b[3].bco'
-      payload: '25388'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[1].b[3].pco'
-      payload: '65535'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[2].b[1].bco'
-      payload: '25388'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[2].b[1].pco'
-      payload: '65535'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[2].b[2].bco'
-      payload: '25388'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[2].b[2].pco'
-      payload: '65535'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[2].b[3].bco'
-      payload: '25388'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[2].b[3].pco'
-      payload: '65535'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[3].b[1].bco'
-      payload: '25388'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[3].b[1].pco'
-      payload: '65535'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[3].b[2].bco'
-      payload: '25388'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[3].b[2].pco'
-      payload: '65535'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[3].b[3].bco'
-      payload: '25388'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[3].b[3].pco'
-      payload: '65535'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[4].b[1].bco'
-      payload: '25388'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[4].b[1].pco'
-      payload: '65535'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[4].b[2].bco'
-      payload: '25388'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[4].b[2].pco'
-      payload: '65535'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[4].b[3].bco'
-      payload: '25388'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[4].b[3].pco'
-      payload: '65535'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[5].b[1].bco'
-      payload: '25388'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[5].b[1].pco'
-      payload: '65535'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[5].b[2].bco'
-      payload: '25388'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[5].b[2].pco'
-      payload: '65535'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[5].b[3].bco'
-      payload: '25388'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[5].b[3].pco'
-      payload: '65535'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[6].b[1].bco'
-      payload: '25388'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[6].b[1].pco'
-      payload: '65535'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[6].b[2].bco'
-      payload: '25388'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[6].b[2].pco'
-      payload: '65535'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[6].b[3].bco'
-      payload: '25388'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[6].b[3].pco'
-      payload: '65535'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[7].b[1].bco'
-      payload: '25388'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[7].b[1].pco'
-      payload: '65535'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[7].b[2].bco'
-      payload: '25388'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[7].b[2].pco'
-      payload: '65535'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[7].b[3].bco'
-      payload: '25388'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[7].b[3].pco'
-      payload: '65535'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[8].b[1].bco'
-      payload: '25388'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[8].b[1].pco'
-      payload: '65535'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[8].b[2].bco'
-      payload: '25388'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[8].b[2].pco'
-      payload: '65535'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[8].b[3].bco'
-      payload: '25388'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[8].b[3].pco'
-      payload: '65535'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[9].b[1].bco'
-      payload: '25388'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[9].b[1].pco'
-      payload: '65535'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[9].b[2].bco'
-      payload: '25388'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[9].b[2].pco'
-      payload: '65535'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[9].b[3].bco'
-      payload: '25388'
-  - service: mqtt.publish
-    data:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[9].b[3].pco'
-      payload: '65535'
-# now write out the highlight colors for our 3 selected pages
+    data_template:
+      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[{{states.input_number.haswitchplate_active_page.state|int}}].b[1].bco'
+      payload_template: >-
+        {% if states.input_number.haswitchplate_active_page.state|int == states.input_number.haswitchplate_pagebutton1_page.state|int -%}
+          65535
+        {%- else -%}
+          25388
+        {%- endif %}
   - service: mqtt.publish
     data_template:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[{{states.input_number.haswitchplate_pagebutton1_page.state|int}}].b[1].bco'
-      payload: '65535'
+      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[{{states.input_number.haswitchplate_active_page.state|int}}].b[1].pco'
+      payload_template: >-
+        {% if states.input_number.haswitchplate_active_page.state|int == states.input_number.haswitchplate_pagebutton1_page.state|int -%}
+          0
+        {%- else -%}
+          65535
+        {%- endif %}
   - service: mqtt.publish
     data_template:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[{{states.input_number.haswitchplate_pagebutton1_page.state|int}}].b[1].pco'
-      payload: '0'
+      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[{{states.input_number.haswitchplate_active_page.state|int}}].b[2].bco'
+      payload_template: >-
+        {% if states.input_number.haswitchplate_active_page.state|int == states.input_number.haswitchplate_pagebutton2_page.state|int -%}
+          65535
+        {%- else -%}
+          25388
+        {%- endif %}
   - service: mqtt.publish
     data_template:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[{{states.input_number.haswitchplate_pagebutton2_page.state|int}}].b[2].bco'
-      payload: '65535'
+      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[{{states.input_number.haswitchplate_active_page.state|int}}].b[2].pco'
+      payload_template: >-
+        {% if states.input_number.haswitchplate_active_page.state|int == states.input_number.haswitchplate_pagebutton2_page.state|int -%}
+         0
+        {%- else -%}
+          65535
+        {%- endif %}
   - service: mqtt.publish
     data_template:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[{{states.input_number.haswitchplate_pagebutton2_page.state|int}}].b[2].pco'
-      payload: '0'
+      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[{{states.input_number.haswitchplate_active_page.state|int}}].b[3].bco'
+      payload_template: >-
+        {% if states.input_number.haswitchplate_active_page.state|int == states.input_number.haswitchplate_pagebutton3_page.state|int -%}
+          65535
+        {%- else -%}
+          25388
+        {%- endif %}
   - service: mqtt.publish
     data_template:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[{{states.input_number.haswitchplate_pagebutton3_page.state|int}}].b[3].bco'
-      payload: '65535'
-  - service: mqtt.publish
-    data_template:
-      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[{{states.input_number.haswitchplate_pagebutton3_page.state|int}}].b[3].pco'
-      payload: '0'
+      topic: 'homeassistant/haswitchplate/HASwitchPlate/command/p[{{states.input_number.haswitchplate_active_page.state|int}}].b[3].pco'
+      payload_template: >-
+        {% if states.input_number.haswitchplate_active_page.state|int == states.input_number.haswitchplate_pagebutton3_page.state|int -%}
+          0
+        {%- else -%}
+          65535
+        {%- endif %}


### PR DESCRIPTION
Hi,
As per my screenshots on the HASS forum, i have modified my code to have the 3 page buttons change their action based on what button you are on at the time, ie;
by default button 1 goes on to "lights 1/2" button 2 is "home" and button 3 is "other".
when button 1 is selected, button 1 then becomes "lights 2/2", and button 3 becomes "dimmers", button 2 stays as "home"
when button 2 is pressed the button text and actions revert to default.

I found that due to 33 MQTT commands (200 odd lines of config) every time i changed a "PageButton Page" the panel was a bit sluggish to update and since most of these were updates to pages that werent being displayed, i optimised the code automation to only update the page we are currently looking at. It is now condensed to only 6 MQTT commands.

Since mine is an edge case of changing PageButton Pages on the fly, ill leave it up to you as to if you want to add this patch or not, as it means that the button states are updated every time a page is loaded as apposed to every time a "PageButton Page" is changed, so it will mean multiple groups of 6 MQTT commands as apposed to occasional groups of 33 MQTT commands