### PR TITLE
More robust handling of media player template sensors

### DIFF
--- a/Home_Assistant/configuration.yaml
+++ b/Home_Assistant/configuration.yaml
@@ -153,11 +153,48 @@ sensor:
   - platform: template
     sensors:
       media_player_title:
-        value_template: '{{ states.media_player.media_player.attributes.media_title }}'
+        friendly_name: Title
+        value_template: >-
+          {%- if states.media_player.kodi.state == "playing" or "paused" -%}
+            {%- if states.media_player.kodi.attributes.media_content_type == "tvshow" -%}
+              S{%- if states.media_player.kodi.attributes.media_season < 10 -%}0{%- endif -%}{{ states.media_player.kodi.attributes.media_season }}E{%- if states.media_player.kodi.attributes.media_episode < 10 -%}0{%- endif -%}{{ states.media_player.kodi.attributes.media_episode }} - {{ states.media_player.kodi.attributes.media_title }}
+            {%- else -%}
+              {{ states.media_player.kodi.attributes.media_title }}
+            {%- endif -%}
+          {%- else -%}
+            
+          {%- endif -%}
+        icon_template: mdi:television-classic
       media_player_artist:
-        value_template: '{{ states.media_player.media_player.attributes.media_artist }}'
+        friendly_name: Series
+        value_template: >-
+          {%- if states.media_player.kodi.state == "playing" or "paused" and states.media_player.kodi.attributes.media_content_type == "tvshow" -%}
+            {{ states.media_player.kodi.attributes.media_series_title }}
+          {%- else -%}
+            
+          {%- endif -%}
+        icon_template: mdi:television-classic
       media_player_volume:
-        value_template: '{{ states.media_player.media_player.attributes.volume_level }}'
+        friendly_name: Volume
+        value_template: >-
+          {%- if states.media_player.kodi.attributes.volume_level -%}
+            {{ states.media_player.kodi.attributes.volume_level * 100}}
+          {%- else -%}
+            0
+          {%- endif -%}
+        unit_of_measurement: '%'
+        icon_template: >-
+          {%- if 66 < states.media_player.kodi.attributes.volume_level * 100 <= 100 -%}
+            mdi:volume-high
+          {%- elif 33 < states.media_player.kodi.attributes.volume_level * 100 <= 66 -%}
+            mdi:volume-medium
+          {%- elif 0 < states.media_player.kodi.attributes.volume_level * 100 <= 33 -%}
+            mdi:volume-low
+          {%- elif states.media_player.kodi.attributes.volume_level * 100 == 0 -%}
+            mdi:volume-off
+          {%- else -%}
+            mdi:volume-mute
+          {%- endif -%}
 # - platform: octoprint
   # name: OctoPrint
   # monitored_conditions:
@@ -170,9 +207,14 @@ sensor:
   # api_key: YOUROCTOPRINTAPIKEY
 
 media_player:
-  - platform: gpmdp
-    name: "Media Player"
-    host: 127.0.0.1
+  - platform: kodi
+    host: 192.168.1.30
+    port: 8080
+    tcp_port: 9090
+    username: !secret kodi_username
+    password: !secret kodi_password
+    enable_websocket: True
+    name: Kodi
 
 alarm_control_panel:
   - platform: manual


### PR DESCRIPTION
In my case, and possibly others, if there's no media playing, the template sensors will no evaluate properly and throw a lot of errors into the error log constantly.  I use Kodi as my media player platform.  The template sensors I have created handle movie titles, tv show names and episodes including adding the leading 0 in the notation "S01E01".  I also handle the default case of nothing playing and insert a blank string.  If I used the example templates without a default case the automation for the media player page on the panel would throw errors as well.