### PR TITLE
Create a new python script for updating foreground/background colors

### DIFF
--- a/Home_Assistant/packages/plate01/hasp_plate01_00_components.yaml
+++ b/Home_Assistant/packages/plate01/hasp_plate01_00_components.yaml
@@ -240,3 +240,41 @@ automation:
         data:
           entity_id: 'input_number.hasp_plate01_activepage'
           value: 1
+
+script:
+##############################################################################
+# Selects the font size to best fit the input text
+# Required arguments:
+#   topic: the topic to publish to
+#   text: the text that should be sized
+  hasp_plate01_font_size_select:
+    sequence:
+      - service: mqtt.publish
+        data:
+          topic: "{{topic}}"
+          payload_template: >
+            {% set string_length = text)|length %}
+            {% if string_length <= 6 -%}
+              3
+            {% elif (string_length > 6) and (string_length <= 10) %}
+              2
+            {% elif (string_length > 10) and (string_length <= 15) %}
+              1
+            {% else %}
+              0
+            {%- endif %}"
+
+# Updates the message on the specified object making sure that the text fits
+# Required arguments:
+#   objectId: the id of the object on the HASP you want to update, eg: p[2].b[5]
+#   text: the text that should be sent
+  hasp_plate01_update_message:
+    sequence:
+      - service: script.hasp_plate01_font_size_select
+        data:
+          topic: "hasp/plate01/command/{{objectId}}.font"
+          text: "{{text}}"
+      - service: mqtt.publish
+        data:
+          topic: "hasp/plate01/command/{{objectId}}.txt"
+          payload_template: "{{text}}"

--- a/Home_Assistant/packages/plate01/hasp_plate01_p0_pages.yaml
+++ b/Home_Assistant/packages/plate01/hasp_plate01_p0_pages.yaml
@@ -52,7 +52,7 @@ automation:
       data_template:
         entity_id: 'input_number.hasp_plate01_activepage'
         value: '{{states.input_number.hasp_plate01_pagebutton1page.state|int}}'
-      
+
 ##############################################################################
 # select hasp_plate01_pagebutton2page in response to page button 2
   - alias: hasp_plate01_p0_PageButton2Action
@@ -89,7 +89,7 @@ automation:
       data_template:
         entity_id: 'input_number.hasp_plate01_activepage'
         value: '{{states.input_number.hasp_plate01_pagebutton2page.state|int}}'
-      
+
 ##############################################################################
 # select hasp_plate01_pagebutton3page in response to page button 3
   - alias: hasp_plate01_p0_PageButton3Action
@@ -154,7 +154,7 @@ automation:
       data_template:
         topic: 'hasp/plate01/command/page'
         payload: '{{ states.input_number.hasp_plate01_activepage.state | int }}'
-      
+
 ##############################################################################
 # Set page button text across all pages to the value selected in the interface
 
@@ -312,55 +312,49 @@ automation:
       topic: 'hasp/plate01/status'
       payload: 'ON'
     action:
-    - service: mqtt.publish
+    - service: python_script.hasp_update_colors
       data_template:
-        topic: 'hasp/plate01/command/p[{{states.input_number.hasp_plate01_activepage.state|int}}].b[1].bco'
-        payload_template: >-
+        nodename: plate01
+        object_id: 'p[{{states.input_number.hasp_plate01_activepage.state|int}}].b[1]'
+        background: >-
           {% if states.input_number.hasp_plate01_activepage.state|int == states.input_number.hasp_plate01_pagebutton1page.state|int -%}
             65535
           {%- else -%}
             25388
           {%- endif %}
-    - service: mqtt.publish
-      data_template:
-        topic: 'hasp/plate01/command/p[{{states.input_number.hasp_plate01_activepage.state|int}}].b[1].pco'
-        payload_template: >-
+        foreground: >-
           {% if states.input_number.hasp_plate01_activepage.state|int == states.input_number.hasp_plate01_pagebutton1page.state|int -%}
             0
           {%- else -%}
             65535
           {%- endif %}
-    - service: mqtt.publish
+    - service: python_script.hasp_update_colors
       data_template:
-        topic: 'hasp/plate01/command/p[{{states.input_number.hasp_plate01_activepage.state|int}}].b[2].bco'
-        payload_template: >-
+        nodename: plate01
+        object_id: 'p[{{states.input_number.hasp_plate01_activepage.state|int}}].b[2]'
+        background: >-
           {% if states.input_number.hasp_plate01_activepage.state|int == states.input_number.hasp_plate01_pagebutton2page.state|int -%}
             65535
           {%- else -%}
             25388
           {%- endif %}
-    - service: mqtt.publish
-      data_template:
-        topic: 'hasp/plate01/command/p[{{states.input_number.hasp_plate01_activepage.state|int}}].b[2].pco'
-        payload_template: >-
+        foreground: >-
           {% if states.input_number.hasp_plate01_activepage.state|int == states.input_number.hasp_plate01_pagebutton2page.state|int -%}
            0
           {%- else -%}
             65535
           {%- endif %}
-    - service: mqtt.publish
+    - service: python_script.hasp_update_colors
       data_template:
-        topic: 'hasp/plate01/command/p[{{states.input_number.hasp_plate01_activepage.state|int}}].b[3].bco'
-        payload_template: >-
+        nodename: plate01
+        object_id: 'p[{{states.input_number.hasp_plate01_activepage.state|int}}].b[3]'
+        background: >-
           {% if states.input_number.hasp_plate01_activepage.state|int == states.input_number.hasp_plate01_pagebutton3page.state|int -%}
             65535
           {%- else -%}
             25388
           {%- endif %}
-    - service: mqtt.publish
-      data_template:
-        topic: 'hasp/plate01/command/p[{{states.input_number.hasp_plate01_activepage.state|int}}].b[3].pco'
-        payload_template: >-
+        foreground: >-
           {% if states.input_number.hasp_plate01_activepage.state|int == states.input_number.hasp_plate01_pagebutton3page.state|int -%}
             0
           {%- else -%}

--- a/Home_Assistant/packages/plate01/hasp_plate01_p1_scenes.yaml
+++ b/Home_Assistant/packages/plate01/hasp_plate01_p1_scenes.yaml
@@ -9,38 +9,22 @@ automation:
       topic: 'hasp/plate01/status'
       payload: 'ON'
     action:
-    - service: mqtt.publish
+    - service: script.hasp_plate01_update_message
       data:
-        topic: 'hasp/plate01/command/p[1].b[4].font'
-        payload: '2'
-    - service: mqtt.publish
+        objectId: 'p[1].b[4]'
+        text: '"Lights On"'
+    - service: script.hasp_plate01_update_message
       data:
-        topic: 'hasp/plate01/command/p[1].b[4].txt'
-        payload: '"Lights On"'
-    - service: mqtt.publish
+        objectId: 'p[1].b[5]'
+        text: '"Daylight"'
+    - service: script.hasp_plate01_update_message
       data:
-        topic: 'hasp/plate01/command/p[1].b[5].font'
-        payload: '2'
-    - service: mqtt.publish
+        objectId: 'p[1].b[6]'
+        text: '"Night"'
+    - service: script.hasp_plate01_update_message
       data:
-        topic: 'hasp/plate01/command/p[1].b[5].txt'
-        payload: '"Daylight"'
-    - service: mqtt.publish
-      data:
-        topic: 'hasp/plate01/command/p[1].b[6].font'
-        payload: '2'
-    - service: mqtt.publish
-      data:
-        topic: 'hasp/plate01/command/p[1].b[6].txt'
-        payload: '"Night"'
-    - service: mqtt.publish
-      data:
-        topic: 'hasp/plate01/command/p[1].b[7].font'
-        payload: '2'
-    - service: mqtt.publish
-      data:
-        topic: 'hasp/plate01/command/p[1].b[7].txt'
-        payload: '"Lights Off"'
+        objectId: 'p[1].b[7]'
+        text: '"Lights Off"'
 
   # Trigger scene.lights_on when p[1].b[4] pressed
   - alias: hasp_plate01_p1_SceneButton4
@@ -51,7 +35,7 @@ automation:
     action:
       service: scene.turn_on
       entity_id: scene.lights_on
-      
+
   # Trigger scene.daylight when p[1].b[5] pressed
   - alias: hasp_plate01_p1_SceneButton5
     trigger:

--- a/Home_Assistant/packages/plate01/hasp_plate01_p2_clock.yaml
+++ b/Home_Assistant/packages/plate01/hasp_plate01_p2_clock.yaml
@@ -9,22 +9,14 @@ automation:
       topic: 'hasp/plate01/status'
       payload: 'ON'
     action:
-    - service: mqtt.publish
+    - service: script.hasp_plate01_update_message
       data:
-        topic: 'hasp/plate01/command/p[2].b[4].font'
-        payload: '3'
-    - service: mqtt.publish
+        objectId: 'p[2].b[4]'
+        text: "\"{{(now().strftime('%I')|int)~now().strftime(':%M')}}\""
+    - service: script.hasp_plate01_update_message
       data:
-        topic: 'hasp/plate01/command/p[2].b[4].txt'
-        payload_template: "\"{{(now().strftime('%I')|int)~now().strftime(':%M')}}\""
-    - service: mqtt.publish
-      data:
-        topic: 'hasp/plate01/command/p[2].b[5].font'
-        payload_template: '{% set datelength = (now().strftime("%B ") ~ now().day)|length %}{% if datelength <= 6 -%}3{% elif (datelength > 6) and (datelength <= 10) %}2{% elif (datelength > 10) and (datelength <= 15) %}1{% else %}0{%- endif %}'
-    - service: mqtt.publish
-      data:
-        topic: 'hasp/plate01/command/p[2].b[5].txt'
-        payload_template: "\"{{now().strftime('%B ') ~ now().day}}\""
+        objectId: 'p[2].b[5]'
+        text: "\"{{now().strftime('%B ') ~ now().day}}\""
 
   # Send the current time every minute
   - alias: hasp_plate01_p2_ClockUpdate
@@ -37,11 +29,11 @@ automation:
       entity_id: 'binary_sensor.plate01_connected'
       state: 'on'
     action:
-    - service: mqtt.publish
+    - service: script.hasp_plate01_update_message
       data:
-        topic: 'hasp/plate01/command/p[2].b[4].txt'
-        payload_template: "\"{{(now().strftime('%I')|int)~now().strftime(':%M')}}\""
-        
+        objectId: 'p[2].b[4]'
+        text: "\"{{(now().strftime('%I')|int)~now().strftime(':%M')}}\""
+
   # Send "Month Day" every day, scaling font to fit
   # 0 consolas 24 - 20 chars x 2 lines (wrapped)
   # 1 consolas 32 - 15 chars x 2 lines (wrapped)
@@ -56,11 +48,7 @@ automation:
       entity_id: 'binary_sensor.plate01_connected'
       state: 'on'
     action:
-    - service: mqtt.publish
+    - service: script.hasp_plate01_update_message
       data:
-        topic: 'hasp/plate01/command/p[2].b[5].font'
-        payload_template: '{% set datelength = (now().strftime("%B ") ~ now().day)|length %}{% if datelength <= 6 -%}3{% elif (datelength > 6) and (datelength <= 10) %}2{% elif (datelength > 10) and (datelength <= 15) %}1{% else %}0{%- endif %}'
-    - service: mqtt.publish
-      data:
-        topic: 'hasp/plate01/command/p[2].b[5].txt'
-        payload_template: "\"{{now().strftime('%B ') ~ now().day}}\""
+        objectId: 'p[2].b[5]'
+        text: "\"{{now().strftime('%B ') ~ now().day}}\""

--- a/Home_Assistant/packages/plate01/hasp_plate01_p2_weather.yaml
+++ b/Home_Assistant/packages/plate01/hasp_plate01_p2_weather.yaml
@@ -11,19 +11,11 @@ automation:
       topic: 'hasp/plate01/status'
       payload: 'ON'
     action:
-    - service: mqtt.publish
+    - service: script.hasp_plate01_update_message
       data:
-        topic: 'hasp/plate01/command/p[2].b[6].font'
-        payload: '3'
-    - service: mqtt.publish
+        objectId: 'p[2].b[6]'
+        text: '"{{states.sensor.weather_temperature.state}}F"'
+    - service: script.hasp_plate01_update_message
       data:
-        topic: 'hasp/plate01/command/p[2].b[6].txt'
-        payload_template: '"{{states.sensor.weather_temperature.state}}F"'
-    - service: mqtt.publish
-      data:
-        topic: 'hasp/plate01/command/p[2].b[7].font'
-        payload_template: '{% if states.sensor.weather_current.state|length <= 6 -%}3{% elif (states.sensor.weather_current.state|length > 6) and (states.sensor.weather_current.state|length <= 10) %}2{% elif (states.sensor.weather_current.state|length > 10) and (states.sensor.weather_current.state|length <= 15) %}1{% else %}0{%- endif %}'
-    - service: mqtt.publish
-      data:
-        topic: 'hasp/plate01/command/p[2].b[7].txt'
-        payload_template: '"{{states.sensor.weather_current.state|wordwrap(20, wrapstring="\\r")}}"'
+        objectId: 'p[2].b[7]'
+        text: '"{{states.sensor.weather_current.state|wordwrap(20, wrapstring="\\r")}}"'

--- a/Home_Assistant/packages/plate01/hasp_plate01_p3_toggles.yaml
+++ b/Home_Assistant/packages/plate01/hasp_plate01_p3_toggles.yaml
@@ -79,19 +79,17 @@ automation:
     - platform: state
       entity_id: light.light_1
     action:
-    - service: mqtt.publish
+    - service: python_script.hasp_update_colors
       data:
-        topic: 'hasp/plate01/command/p[3].b[4].bco'
-        payload_template: >-
+        nodename: plate01
+        object_id: 'p[3].b[4]'
+        background: >-
           {% if states.light.light_1.state == "on" -%}
             65535
           {%- else -%}
             25388
           {%- endif %}
-    - service: mqtt.publish
-      data_template:
-        topic: 'hasp/plate01/command/p[3].b[4].pco'
-        payload_template: >-
+        foreground: >-
           {% if states.light.light_1.state == "on" -%}
             0
           {%- else -%}
@@ -107,19 +105,17 @@ automation:
     - platform: state
       entity_id: light.light_2
     action:
-    - service: mqtt.publish
+    - service: python_script.hasp_update_colors
       data:
-        topic: 'hasp/plate01/command/p[3].b[5].bco'
-        payload_template: >-
+        nodename: plate01
+        object_id: 'p[3].b[5]'
+        background: >-
           {% if states.light.light_2.state == "on" -%}
             65535
           {%- else -%}
             25388
           {%- endif %}
-    - service: mqtt.publish
-      data_template:
-        topic: 'hasp/plate01/command/p[3].b[5].pco'
-        payload_template: >-
+        foreground: >-
           {% if states.light.light_2.state == "on" -%}
             0
           {%- else -%}
@@ -135,19 +131,17 @@ automation:
     - platform: state
       entity_id: light.light_3
     action:
-    - service: mqtt.publish
+    - service: python_script.hasp_update_colors
       data:
-        topic: 'hasp/plate01/command/p[3].b[6].bco'
-        payload_template: >-
+        nodename: plate01
+        object_id: 'p[3].b[6]'
+        background: >-
           {% if states.light.light_3.state == "on" -%}
             65535
           {%- else -%}
             25388
           {%- endif %}
-    - service: mqtt.publish
-      data_template:
-        topic: 'hasp/plate01/command/p[3].b[6].pco'
-        payload_template: >-
+        foreground: >-
           {% if states.light.light_3.state == "on" -%}
             0
           {%- else -%}
@@ -163,19 +157,17 @@ automation:
     - platform: state
       entity_id: group.light_toggle_group
     action:
-    - service: mqtt.publish
+    - service: python_script.hasp_update_colors
       data:
-        topic: 'hasp/plate01/command/p[3].b[7].bco'
-        payload_template: >-
+        nodename: plate01
+        object_id: 'p[3].b[7]'
+        background: >-
           {% if states.group.light_toggle_group.state == "on" -%}
             25388
           {%- else -%}
             65535
           {%- endif %}
-    - service: mqtt.publish
-      data_template:
-        topic: 'hasp/plate01/command/p[3].b[7].pco'
-        payload_template: >-
+        foreground: >-
           {% if states.group.light_toggle_group.state == "on" -%}
             65535
           {%- else -%}

--- a/Home_Assistant/packages/plate01/hasp_plate01_p3_toggles.yaml
+++ b/Home_Assistant/packages/plate01/hasp_plate01_p3_toggles.yaml
@@ -8,30 +8,18 @@ automation:
       topic: 'hasp/plate01/status'
       payload: 'ON'
     action:
-    - service: mqtt.publish
+    - service: script.hasp_plate01_update_message
       data:
-        topic: 'hasp/plate01/command/p[3].b[4].font'
-        payload: '2'
-    - service: mqtt.publish
+        objectId: 'p[3].b[4]'
+        text: '"Light 1"'
+    - service: script.hasp_plate01_update_message
       data:
-        topic: 'hasp/plate01/command/p[3].b[4].txt'
-        payload: '"Light 1"'
-    - service: mqtt.publish
+        objectId: 'p[3].b[5]'
+        text: '"Light 2"'
+    - service: script.hasp_plate01_update_message
       data:
-        topic: 'hasp/plate01/command/p[3].b[5].font'
-        payload: '2'
-    - service: mqtt.publish
-      data:
-        topic: 'hasp/plate01/command/p[3].b[5].txt'
-        payload: '"Light 2"'
-    - service: mqtt.publish
-      data:
-        topic: 'hasp/plate01/command/p[3].b[6].font'
-        payload: '2'
-    - service: mqtt.publish
-      data:
-        topic: 'hasp/plate01/command/p[3].b[6].txt'
-        payload: '"Light 3"'
+        objectId: 'p[3].b[6]'
+        text: '"Light 3"'
     - service: mqtt.publish
       data:
         topic: 'hasp/plate01/command/p[3].b[7].font'
@@ -46,7 +34,7 @@ automation:
     action:
       service: homeassistant.toggle
       entity_id: light.light_1
-      
+
   # Toggle light2 when p[3].b[5] pressed
   - alias: hasp_plate01_p3_ToggleLight2
     trigger:
@@ -81,7 +69,7 @@ automation:
             homeassistant.turn_on
           {%- endif %}
       entity_id: group.light_toggle_group
-      
+
   # Toggle colors on p[3].b[4] when light1 changes
   - alias: hasp_plate01_p3_ToggleColor1
     trigger:

--- a/Home_Assistant/packages/plate01/hasp_plate01_p4_dimmers.yaml
+++ b/Home_Assistant/packages/plate01/hasp_plate01_p4_dimmers.yaml
@@ -7,19 +7,19 @@ automation:
       topic: 'hasp/plate01/status'
       payload: 'ON'
     action:
-    - service: mqtt.publish
+    - service: script.hasp_plate01_update_message
       data:
-        topic: 'hasp/plate01/command/p[4].b[4].txt'
-        payload: '"Light 1"'
-    - service: mqtt.publish
+        objectId: 'p[4].b[4]'
+        text: '"Light 1"'
+    - service: script.hasp_plate01_update_message
       data:
-        topic: 'hasp/plate01/command/p[4].b[5].txt'
-        payload: '"Light 2"'
-    - service: mqtt.publish
+        objectId: 'p[4].b[5]'
+        text: '"Light 2"'
+    - service: script.hasp_plate01_update_message
       data:
-        topic: 'hasp/plate01/command/p[4].b[6].txt'
-        payload: '"Light 3"'
-  
+        objectId: 'p[4].b[6]'
+        text: '"Light 3"'
+
   - alias: hasp_plate01_p4_Dimmer7UpdateHass
     trigger:
     - platform: mqtt
@@ -29,7 +29,7 @@ automation:
       data_template:
         entity_id: light.light_1
         brightness: '{{ trigger.payload }}'
-  
+
   - alias: hasp_plate01_p4_Dimmer7UpdateHASP
     trigger:
     - platform: state
@@ -39,7 +39,7 @@ automation:
       data_template:
         topic: 'hasp/plate01/command/p[4].b[7].val'
         payload_template: '{{states.light.light_1.attributes.brightness|default(0)|int}}'
-  
+
   - alias: hasp_plate01_p4_Dimmer8UpdateHass
     trigger:
     - platform: mqtt
@@ -49,7 +49,7 @@ automation:
       data_template:
         entity_id: light.light_2
         brightness: '{{ trigger.payload }}'
-  
+
   - alias: hasp_plate01_p4_Dimmer8UpdateHASP
     trigger:
     - platform: state
@@ -59,7 +59,7 @@ automation:
       data_template:
         topic: 'hasp/plate01/command/p[4].b[8].val'
         payload_template: '{{states.light.light_2.attributes.brightness|default(0)|int}}'
-  
+
   - alias: hasp_plate01_p4_Dimmer9UpdateHass
     trigger:
     - platform: mqtt
@@ -69,7 +69,7 @@ automation:
       data_template:
         entity_id: light.light_3
         brightness: '{{ trigger.payload }}'
-  
+
   - alias: hasp_plate01_p4_Dimmer9UpdateHASP
     trigger:
     - platform: state

--- a/Home_Assistant/packages/plate01/hasp_plate01_p7_alarm.yaml
+++ b/Home_Assistant/packages/plate01/hasp_plate01_p7_alarm.yaml
@@ -97,7 +97,7 @@ automation:
       data:
         topic: 'hasp/plate01/command/p[7].b[15].font'
         payload: '0'
-  
+
   # set key labels at system start when system is disarmed, or when switching to disarmed
   - alias: hasp_plate01_p7_AlarmDisarmed
     trigger:
@@ -107,7 +107,7 @@ automation:
     - platform: state
       entity_id: alarm_control_panel.ha_alarm
       to: 'disarmed'
-    condition: 
+    condition:
       condition: state
       entity_id: alarm_control_panel.ha_alarm
       state: 'disarmed'
@@ -120,14 +120,12 @@ automation:
       data:
         topic: 'hasp/plate01/command/p[7].b[13].font'
         payload: '0'
-    - service: mqtt.publish
+    - service: python_script.hasp_update_colors
       data:
-        topic: 'hasp/plate01/command/p[7].b[13].pco'
-        payload: '63488'
-    - service: mqtt.publish
-      data:
-        topic: 'hasp/plate01/command/p[7].b[13].bco'
-        payload: '65535'
+        nodename: plate01
+        object_id: 'p[7].b[13]'
+        background: '65535'
+        foregound: '63488'
     - service: mqtt.publish
       data:
         topic: 'hasp/plate01/command/p[7].b[15].txt'
@@ -136,15 +134,13 @@ automation:
       data:
         topic: 'hasp/plate01/command/p[7].b[15].font'
         payload: '1'
-    - service: mqtt.publish
+    - service: python_script.hasp_update_colors
       data:
-        topic: 'hasp/plate01/command/p[7].b[15].pco'
-        payload: '65535'
-    - service: mqtt.publish
-      data:
-        topic: 'hasp/plate01/command/p[7].b[15].bco'
-        payload: '63488'
-  
+        nodename: plate01
+        object_id: 'p[7].b[15]'
+        background: '63488'
+        foregound: '65535'
+
   # set key labels at system start when system is armed_away, or when switching to armed_away
   - alias: hasp_plate01_p7_AlarmArmed
     trigger:
@@ -154,7 +150,7 @@ automation:
     - platform: state
       entity_id: alarm_control_panel.ha_alarm
       to: 'armed_away'
-    condition: 
+    condition:
       condition: state
       entity_id: alarm_control_panel.ha_alarm
       state: 'armed_away'
@@ -167,14 +163,12 @@ automation:
       data:
         topic: 'hasp/plate01/command/p[7].b[13].font'
         payload: '0'
-    - service: mqtt.publish
+    - service: python_script.hasp_update_colors
       data:
-        topic: 'hasp/plate01/command/p[7].b[13].pco'
-        payload: '65535'
-    - service: mqtt.publish
-      data:
-        topic: 'hasp/plate01/command/p[7].b[13].bco'
-        payload: '63488'
+        nodename: plate01
+        object_id: 'p[7].b[13]'
+        background: '63488'
+        foregound: '65535'
     - service: mqtt.publish
       data:
         topic: 'hasp/plate01/command/p[7].b[15].txt'
@@ -183,15 +177,13 @@ automation:
       data:
         topic: 'hasp/plate01/command/p[7].b[15].font'
         payload: '0'
-    - service: mqtt.publish
+    - service: python_script.hasp_update_colors
       data:
-        topic: 'hasp/plate01/command/p[7].b[13].pco'
-        payload: '63488'
-    - service: mqtt.publish
-      data:
-        topic: 'hasp/plate01/command/p[7].b[13].bco'
-        payload: '65535'
-        
+        nodename: plate01
+        object_id: 'p[7].b[13]'
+        background: '65535'
+        foregound: '63488'
+
   # This automation catches the key presses 1-9 and sets our input numbers in response.
   # Button p[7]b[4] is labeled 1, so I'm grabbing buttons p[7]b[4] through p[7]b[13]
   # then subtracting 3.  The math doesn't work out for button "0" so that will be handled
@@ -202,7 +194,7 @@ automation:
     - platform: mqtt
       topic: 'hasp/plate01/state/+'
       payload: 'ON'
-    condition: 
+    condition:
       condition: template
       value_template: '{{ (trigger.topic.split("/")[-1].split("p[")[1].split("]")[0]|int == 7) and ( 4 <= trigger.topic.split("/")[-1].split("].b[")[1].strip("]")|int <= 12) }}'
     action:
@@ -245,7 +237,7 @@ automation:
       data:
         entity_id: input_number.hasp_plate01_alarmcode4
         value: '0'
-  
+
   # Alarm panel is pending arm so update panel text
   - alias: hasp_plate01_p7_AlarmStatusPending
     trigger:
@@ -257,15 +249,15 @@ automation:
       data:
         topic: 'hasp/plate01/command/p[7].b[13].txt'
         payload: '"ARMING"'
-  
+
   # User is attempting to disarm the panel.  Send the alarm service our collected code then
-  # reset all the sliders.      
+  # reset all the sliders.
   - alias: hasp_plate01_p7_AlarmDisarm
     trigger:
       platform: mqtt
       topic: 'hasp/plate01/state/p[7].b[15]'
       payload: 'OFF'
-    condition: 
+    condition:
       condition: state
       entity_id: alarm_control_panel.ha_alarm
       state: 'armed_away'
@@ -290,7 +282,7 @@ automation:
       data_template:
         entity_id: input_number.hasp_plate01_alarmcode4
         value: '-1'
-        
+
   # User is attempting to arm the panel.  Send the alarm service our collected code then
   # reset all the sliders.
   - alias: hasp_plate01_p7_AlarmArm
@@ -298,7 +290,7 @@ automation:
       platform: mqtt
       topic: 'hasp/plate01/state/p[7].b[15]'
       payload: 'OFF'
-    condition: 
+    condition:
       condition: state
       entity_id: alarm_control_panel.ha_alarm
       state: 'disarmed'

--- a/Home_Assistant/packages/plate01/hasp_plate01_p8_media.yaml
+++ b/Home_Assistant/packages/plate01/hasp_plate01_p8_media.yaml
@@ -33,7 +33,7 @@ automation:
       data:
         topic: 'hasp/plate01/command/p[8].b[8].txt'
         payload: '":"'
-  
+
   # Play/Pause button action
   - alias: hasp_plate01_p8_MediaPauseButton7
     trigger:
@@ -43,7 +43,7 @@ automation:
     action:
       service: media_player.media_play_pause
       entity_id: media_player.media_player
-  
+
   # Prev Track button action
   - alias: hasp_plate01_p8_MediaPrevTrackButton6
     trigger:
@@ -53,7 +53,7 @@ automation:
     action:
       service: media_player.media_previous_track
       entity_id: media_player.media_player
-      
+
   # Next Track button action
   - alias: hasp_plate01_p8_MediaNextTrackButton8
     trigger:
@@ -63,7 +63,7 @@ automation:
     action:
       service: media_player.media_next_track
       entity_id: media_player.media_player
-      
+
   # Scale media information fonts to fit
   # 0 consolas 24 - 20 chars x 2 lines (wrapped)
   # 1 consolas 32 - 15 chars x 2 lines (wrapped)
@@ -77,15 +77,11 @@ automation:
       topic: 'hasp/plate01/status'
       payload: 'ON'
     action:
-    - service: mqtt.publish
+    - service: script.hasp_plate01_update_message
       data:
-        topic: 'hasp/plate01/command/p[8].b[4].font'
-        payload_template: '{% if states.sensor.media_player_artist.state|length <= 6 -%}3{% elif (states.sensor.media_player_artist.state|length > 6) and (states.sensor.media_player_artist.state|length <= 10) %}2{% elif (states.sensor.media_player_artist.state|length > 10) and (states.sensor.media_player_artist.state|length <= 15) %}1{% else %}0{%- endif %}'
-    - service: mqtt.publish
-      data:
-        topic: 'hasp/plate01/command/p[8].b[4].txt'
-        payload_template: '"{{ states.sensor.media_player_artist.state|wordwrap(20, wrapstring="\\r") }}"'
-  
+        objectId: 'p[8].b[4]'
+        text: '"{{ states.sensor.media_player_artist.state|wordwrap(20, wrapstring="\\r") }}"'
+
   - alias: hasp_plate01_p8_MediaTitle
     trigger:
     - platform: state
@@ -94,15 +90,11 @@ automation:
       topic: 'hasp/plate01/status'
       payload: 'ON'
     action:
-    - service: mqtt.publish
+    - service: script.hasp_plate01_update_message
       data:
-        topic: 'hasp/plate01/command/p[8].b[5].font'
-        payload_template: '{% if states.sensor.media_player_title.state|length <= 6 -%}3{% elif (states.sensor.media_player_title.state|length > 6) and (states.sensor.media_player_title.state|length <= 10) %}2{% elif (states.sensor.media_player_title.state|length > 10) and (states.sensor.media_player_title.state|length <= 15) %}1{% else %}0{%- endif %}'
-    - service: mqtt.publish
-      data:
-        topic: 'hasp/plate01/command/p[8].b[5].txt'
-        payload_template: '"{{ states.sensor.media_player_title.state|wordwrap(20, wrapstring="\\r") }}"'
-  
+        objectId: 'p[8].b[5]'
+        text: '"{{ states.sensor.media_player_title.state|wordwrap(20, wrapstring="\\r") }}"'
+
   - alias: hasp_plate01_p8_MediaPlayPause
     trigger:
     - platform: state
@@ -112,7 +104,7 @@ automation:
       data:
         topic: 'hasp/plate01/command/p[8].b[7].txt'
         payload_template: "\"{%- if is_state('media_player.media_player', 'playing') %};{% elif is_state('media_player.media_player', 'paused') %}4{% endif -%}\""
-  
+
   # Volume slider value published, apply published state
   - alias: hasp_plate01_p8_MediaVolSliderUpdateHass
     trigger:
@@ -123,9 +115,9 @@ automation:
       data_template:
         entity_id: media_player.media_player
         volume_level: '{{ (trigger.payload|int) / 100 }}'
-        
-  # Volume slider value changed by hass, update HASP 
-  - alias: hasp_plate01_p8_MediaVolSliderUpdateHASP 
+
+  # Volume slider value changed by hass, update HASP
+  - alias: hasp_plate01_p8_MediaVolSliderUpdateHASP
     trigger:
     - platform: state
       entity_id: sensor.media_player_volume

--- a/Home_Assistant/packages/plate01/hasp_plate01_p9_3dprint.yaml
+++ b/Home_Assistant/packages/plate01/hasp_plate01_p9_3dprint.yaml
@@ -25,14 +25,12 @@ automation:
     - platform: state
       entity_id: sensor.octoprint_job_percentage
     action:
-    - service: mqtt.publish
+    - service: python_script.hasp_update_colors
       data:
-        topic: 'hasp/plate01/command/p[9].b[4].bco'
-        payload: '5285'
-    - service: mqtt.publish
-      data:
-        topic: 'hasp/plate01/command/p[9].b[4].pco'
-        payload: '65535'
+        nodename: plate01
+        object_id: 'p[9].b[4]'
+        background: '5285'
+        foreground: '65535'
     - service: script.hasp_plate01_update_message
       data:
         objectId: 'p[9].b[4]'
@@ -44,14 +42,12 @@ automation:
     - platform: template
       value_template: "{% if is_state('sensor.octoprint_current_state', 'Operational') %}true{% endif %}"
     action:
-    - service: mqtt.publish
+    - service: python_script.hasp_update_colors
       data:
-        topic: 'hasp/plate01/command/p[9].b[4].bco'
-        payload: '65535'
-    - service: mqtt.publish
-      data:
-        topic: 'hasp/plate01/command/p[9].b[4].pco'
-        payload: '5285'
+        nodename: plate01
+        object_id: 'p[9].b[4]'
+        background: '65535'
+        foreground: '5285'
     - service: script.hasp_plate01_update_message
       data:
         objectId: 'p[9].b[4]'
@@ -63,14 +59,12 @@ automation:
       platform: template
       value_template: "{% if is_state('sensor.octoprint_current_state', 'Paused') %}true{% endif %}"
     action:
-    - service: mqtt.publish
+    - service: python_script.hasp_update_colors
       data:
-        topic: 'hasp/plate01/command/p[9].b[4].bco'
-        payload: '65535'
-    - service: mqtt.publish
-      data:
-        topic: 'hasp/plate01/command/p[9].b[4].pco'
-        payload: '63488'
+        nodename: plate01
+        object_id: 'p[9].b[4]'
+        background: '65535'
+        foreground: '63488'
     - service: script.hasp_plate01_update_message
       data:
         objectId: 'p[9].b[4]'

--- a/Home_Assistant/packages/plate01/hasp_plate01_p9_3dprint.yaml
+++ b/Home_Assistant/packages/plate01/hasp_plate01_p9_3dprint.yaml
@@ -16,14 +16,14 @@ automation:
       data:
         topic: 'hasp/plate01/command/p[9].b[5].font'
         payload: '1'
-   
+
   # Update status while printing
   - alias: hasp_plate01_p9_3DPrinterPrinting
     trigger:
     - platform: template
       value_template: "{% if is_state('sensor.octoprint_current_state', 'Printing') %}true{% endif %}"
     - platform: state
-      entity_id: sensor.octoprint_job_percentage    
+      entity_id: sensor.octoprint_job_percentage
     action:
     - service: mqtt.publish
       data:
@@ -33,14 +33,10 @@ automation:
       data:
         topic: 'hasp/plate01/command/p[9].b[4].pco'
         payload: '65535'
-    - service: mqtt.publish
+    - service: script.hasp_plate01_update_message
       data:
-        topic: 'hasp/plate01/command/p[9].b[4].font'
-        payload: '1'
-    - service: mqtt.publish
-      data:
-        topic: 'hasp/plate01/command/p[9].b[4].txt'
-        payload_template: '"Status:Printing\rProgress:{{(states.sensor.octoprint_job_percentage.state)|default(0)|round(1)}}%"'
+        objectId: 'p[9].b[4]'
+        text: '"Status:Printing\rProgress:{{(states.sensor.octoprint_job_percentage.state)|default(0)|round(1)}}%"'
 
   # Update status while printer is online but not printing
   - alias: hasp_plate01_p9_3DPrinterOperational
@@ -56,15 +52,11 @@ automation:
       data:
         topic: 'hasp/plate01/command/p[9].b[4].pco'
         payload: '5285'
-    - service: mqtt.publish
+    - service: script.hasp_plate01_update_message
       data:
-        topic: 'hasp/plate01/command/p[9].b[4].font'
-        payload: '2'
-    - service: mqtt.publish
-      data:
-        topic: 'hasp/plate01/command/p[9].b[4].txt'
-        payload_template: '"Online"'
-  
+        objectId: 'p[9].b[4]'
+        text: '"Online"'
+
   # Update status while printer is paused
   - alias: hasp_plate01_p9_3DPrinterPaused
     trigger:
@@ -79,15 +71,11 @@ automation:
       data:
         topic: 'hasp/plate01/command/p[9].b[4].pco'
         payload: '63488'
-    - service: mqtt.publish
+    - service: script.hasp_plate01_update_message
       data:
-        topic: 'hasp/plate01/command/p[9].b[4].font'
-        payload: '2'
-    - service: mqtt.publish
-      data:
-        topic: 'hasp/plate01/command/p[9].b[4].txt'
-        payload_template: '"Paused"'
-  
+        objectId: 'p[9].b[4]'
+        text: '"Paused"'
+
   # Show the head and bed temps.  My locale is set for deg F, and I want deg C, so
   # the values are being converted in the template code
   - alias: hasp_plate01_p9_3DPrinterTempText
@@ -109,8 +97,8 @@ automation:
       data:
         topic: 'hasp/plate01/command/p[9].b[5].txt'
         payload_template: '"Head: {{((states.sensor.octoprint_actual_tool0_temp.state|float-32)*(5/9))|round(1)}}/{{((states.sensor.octoprint_target_tool0_temp.state|float-32)*(5/9))|int}}\r Bed: {{((states.sensor.octoprint_actual_bed_temp.state|float-32)*(5/9))|round(1)}}/{{((states.sensor.octoprint_target_bed_temp.state|float-32)*(5/9))|int}}"'
-  
-  # Every 30 seconds (default octoprint polling interval in Hass), add one pixel to the graph.      
+
+  # Every 30 seconds (default octoprint polling interval in Hass), add one pixel to the graph.
   # The graph on page 9 has 4 divisions, so we're calling the origin (y=0 in the graph) 50deg C and the top line 250deg C
   # each pixel is one data point, the object on the page is 133 points tall
   # my Location is using deg F, so I need to convert from F to C then map 50-250 into a range of 1-133

--- a/Home_Assistant/python_scripts/hasp_update_colors.py
+++ b/Home_Assistant/python_scripts/hasp_update_colors.py
@@ -1,0 +1,34 @@
+###############################################################################
+#  @author       :  Rohan Kapoor
+#  @date         :  08/26/2018
+#  @name         :  hasp_update_colors.py
+#  @description  :  Handles updating background/foreground colors for
+#                   a HASP device. At least one of background/foreground
+#                   must be provided
+#  @params       :  All params are taken as strings from Home Assistant
+#   nodename: the name of the hasp device, eg: plat01
+#   object_id: the id of the object on the HASP you want to update, eg: p[2].b[5]
+#   background: the color to display on the background on the HASP device
+#   foreground: the color to display on the foreground on the HASP device
+###############################################################################
+
+nodename = data.get('nodename')
+object_id = data.get('object_id')
+background = data.get('background')
+foreground = data.get('foreground')
+
+base_topic = 'hasp/{}/command/{}'.format(nodename, object_id)
+
+if background:
+    background_payload = {
+        'topic': '{}.bco'.format(base_topic),
+        'payload': '{}'.format(background)
+    }
+    hass.services.call('mqtt', 'publish', background_payload)
+
+if foreground:
+    foreground_payload = {
+        'topic': '{}.pco'.format(base_topic),
+        'payload': '{}'.format(foreground)
+    }
+    hass.services.call('mqtt', 'publish', foreground_payload)


### PR DESCRIPTION
Hey @aderusha,

In the same vein as my previous simplifications for updating font size/text (#17, #19), I've also written a python_script to simplify the logic of picking colors. This allows setting the foreground/background color in one service call rather than doing this separately in each automation that needs to do it.

**Here's an example**:

Before:
```
    - service: mqtt.publish
      data:
        topic: 'hasp/plate01/command/p[9].b[4].bco'
        payload: '5285'

    - service: mqtt.publish
      data:
        topic: 'hasp/plate01/command/p[9].b[4].pco'
        payload: '65535'
```
After:
```
    - service: python_script.hasp_update_colors
      data:
        nodename: plate01
        object_id: 'p[9].b[4]'
        background: '5285'
        foreground: '65535'
```

I'd recommend merging this in after #19 since it also requires setting up the python_script component and (copying in the scripts) that is demonstrated there. Once that's merged, this will also require a small documentation update and a change to `deployhasp.sh` to download and grab the new script as well.