### PR TITLE
Add HTML validation on `nodeName` field

### DIFF
--- a/Arduino_Sketch/HASwitchPlate/HASwitchPlate.ino
+++ b/Arduino_Sketch/HASwitchPlate/HASwitchPlate.ino
@@ -1418,10 +1418,11 @@ void webHandleRoot()
   httpMessage += String(haspNode);
   httpMessage += String(F("</h1>"));
 
+  httpMessage += String(F("<style>input:invalid { border: 1px solid red; }</style>"));
   httpMessage += String(F("<form method='POST' action='saveConfig'>"));
   httpMessage += String(F("<b>WiFi SSID</b> <i><small>(required)</small></i><input id='wifiSSID' required name='wifiSSID' maxlength=32 placeholder='WiFi SSID' value='")) + String(WiFi.SSID()) + "'>";
   httpMessage += String(F("<br/><b>WiFi Password</b> <i><small>(required)</small></i><input id='wifiPass' required name='wifiPass' type='password' maxlength=64 placeholder='WiFi Password' value='")) + String("********") + "'>";
-  httpMessage += String(F("<br/><br/><b>HASP Node Name</b> <i><small>(lowercase, required)</small></i><input id='haspNode' required name='haspNode' maxlength=15 placeholder='HASP Node Name' value='")) + String(haspNode) + "'>";
+  httpMessage += String(F("<br/><br/><b>HASP Node Name</b> <i><small>(lowercase, required)</small></i><input id='haspNode' required name='haspNode' maxlength=15 placeholder='HASP Node Name' pattern='[a-z0-9_]*' value='")) + String(haspNode) + "'>";
   httpMessage += String(F("<br/><br/><b>Group Name</b> <i><small>(required)</small></i><input id='groupName' required name='groupName' maxlength=15 placeholder='Group Name' value='")) + String(groupName) + "'>";
   httpMessage += String(F("<br/><br/><b>MQTT Broker</b> <i><small>(required)</small></i><input id='mqttServer' required name='mqttServer' maxlength=63 placeholder='mqttServer' value='")) + String(mqttServer) + "'>";
   httpMessage += String(F("<br/><b>MQTT Port</b> <i><small>(required)</small></i><input id='mqttPort' required name='mqttPort' type='number' maxlength=5 placeholder='mqttPort' value='")) + String(mqttPort) + "'>";


### PR DESCRIPTION
First off: Thanks for this project!  I'm super excited to get it up and working.

While installing this I first tried to name my module `bedroom-plate`, and was confused why it wasn't working.  It turns out that the generated topics were using `hasp/bedroom_plate`.  Changing the `nodeName` field to match made things work as expected.

To help others while setting this up, I thought it might make sense to add some visual queues that the name was invalid:

![image](https://user-images.githubusercontent.com/207950/50568446-cb1ab200-0d06-11e9-8b1d-7cb201d7f170.png)

It may make sense to also update the hint text, but I didn't want to make it too wordy.  If you'd like that as well, just let me know you would like it to be and I'd be happy to make the change.