### PR TITLE
Fixed volume display on media page

### DIFF
--- a/Home_Assistant/packages/plate01/hasp_plate01_p8_media.yaml
+++ b/Home_Assistant/packages/plate01/hasp_plate01_p8_media.yaml
@@ -172,4 +172,4 @@ automation:
     - service: mqtt.publish
       data:
         topic: 'hasp/plate01/command/p[8].b[9].val'
-        payload_template: '{{ (states.sensor.media_player_volume.state * 100)|int }}'
+        payload_template: '{{ (states.sensor.media_player_volume.state | float * 100) | int }}'


### PR DESCRIPTION
I noticed the slider value for volume wasn't showing the current volume level and tracked it down to the value not being cast to a float correctly. This fixes the problem for me so I thought I'd send it over!