### PR TITLE
Converted formatting rules to use JSON Command topic, reducing # of required Items.

### DIFF
--- a/contrib/openHAB/HASP-Foyer.items
+++ b/contrib/openHAB/HASP-Foyer.items
@@ -1,12 +1,6 @@
 Group HASP_Plate02_Button1_Group
 Group HASP_Plate02_Button2_Group
 Group HASP_Plate02_Button3_Group
-Group HASP_Plate02_Button1_Text_Group
-Group HASP_Plate02_Button2_Text_Group
-Group HASP_Plate02_Button3_Text_Group
-Group HASP_Plate02_Button1_Bcol_Group
-Group HASP_Plate02_Button2_Bcol_Group
-Group HASP_Plate02_Button3_Bcol_Group
 Group HASP_Plate02_Page1_Button_Group
 Group HASP_Plate02_Page2_Button_Group
 Group HASP_Plate02_Page3_Button_Group
@@ -31,24 +25,6 @@ Switch HASP_Plate02_Button_P6B1 "HASP Plate 02 Page 6 Button 1 State [%s]" (HASP
 Switch HASP_Plate02_Button_P7B1 "HASP Plate 02 Page 7 Button 1 State [%s]" (HASP_Plate02_Button1_Group)  {mqtt="<[broker:hasp/plate02/state/p[7].b[1]:state:default]"}
 Switch HASP_Plate02_Button_P8B1 "HASP Plate 02 Page 8 Button 1 State [%s]" (HASP_Plate02_Button1_Group)  {mqtt="<[broker:hasp/plate02/state/p[8].b[1]:state:default]"}
 Switch HASP_Plate02_Button_P9B1 "HASP Plate 02 Page 9 Button 1 State [%s]" (HASP_Plate02_Button1_Group)  {mqtt="<[broker:hasp/plate02/state/p[9].b[1]:state:default]"}
-String HASP_Plate02_Button_P1B1_Text "HASP Plate 02 Page 1 Button 1 Text [%s]" (HASP_Plate02_Button1_Text_Group) {mqtt=">[broker:hasp/plate02/command/p[1].b[1].txt:command:*:default]"}
-String HASP_Plate02_Button_P2B1_Text "HASP Plate 02 Page 2 Button 1 Text [%s]" (HASP_Plate02_Button1_Text_Group) {mqtt=">[broker:hasp/plate02/command/p[2].b[1].txt:command:*:default]"}
-String HASP_Plate02_Button_P3B1_Text "HASP Plate 02 Page 3 Button 1 Text [%s]" (HASP_Plate02_Button1_Text_Group) {mqtt=">[broker:hasp/plate02/command/p[3].b[1].txt:command:*:default]"}
-String HASP_Plate02_Button_P4B1_Text "HASP Plate 02 Page 4 Button 1 Text [%s]" (HASP_Plate02_Button1_Text_Group) {mqtt=">[broker:hasp/plate02/command/p[4].b[1].txt:command:*:default]"}
-String HASP_Plate02_Button_P5B1_Text "HASP Plate 02 Page 5 Button 1 Text [%s]" (HASP_Plate02_Button1_Text_Group) {mqtt=">[broker:hasp/plate02/command/p[5].b[1].txt:command:*:default]"}
-String HASP_Plate02_Button_P6B1_Text "HASP Plate 02 Page 6 Button 1 Text [%s]" (HASP_Plate02_Button1_Text_Group) {mqtt=">[broker:hasp/plate02/command/p[6].b[1].txt:command:*:default]"}
-String HASP_Plate02_Button_P7B1_Text "HASP Plate 02 Page 7 Button 1 Text [%s]" (HASP_Plate02_Button1_Text_Group) {mqtt=">[broker:hasp/plate02/command/p[7].b[1].txt:command:*:default]"}
-String HASP_Plate02_Button_P8B1_Text "HASP Plate 02 Page 8 Button 1 Text [%s]" (HASP_Plate02_Button1_Text_Group) {mqtt=">[broker:hasp/plate02/command/p[8].b[1].txt:command:*:default]"}
-String HASP_Plate02_Button_P9B1_Text "HASP Plate 02 Page 9 Button 1 Text [%s]" (HASP_Plate02_Button1_Text_Group) {mqtt=">[broker:hasp/plate02/command/p[9].b[1].txt:command:*:default]"}
-Number HASP_Plate02_Button_P1B1_Bcol "HASP Plate 02 Page 1 Button 1 BCol [%d]" (HASP_Plate02_Button1_Bcol_Group) {mqtt=">[broker:hasp/plate02/command/p[1].b[1].bco:command:*:default]"}
-Number HASP_Plate02_Button_P2B1_Bcol "HASP Plate 02 Page 2 Button 1 BCol [%d]" (HASP_Plate02_Button1_Bcol_Group) {mqtt=">[broker:hasp/plate02/command/p[2].b[1].bco:command:*:default]"}
-Number HASP_Plate02_Button_P3B1_Bcol "HASP Plate 02 Page 3 Button 1 BCol [%d]" (HASP_Plate02_Button1_Bcol_Group) {mqtt=">[broker:hasp/plate02/command/p[3].b[1].bco:command:*:default]"}
-Number HASP_Plate02_Button_P4B1_Bcol "HASP Plate 02 Page 4 Button 1 BCol [%d]" (HASP_Plate02_Button1_Bcol_Group) {mqtt=">[broker:hasp/plate02/command/p[4].b[1].bco:command:*:default]"}
-Number HASP_Plate02_Button_P5B1_Bcol "HASP Plate 02 Page 5 Button 1 BCol [%d]" (HASP_Plate02_Button1_Bcol_Group) {mqtt=">[broker:hasp/plate02/command/p[5].b[1].bco:command:*:default]"}
-Number HASP_Plate02_Button_P6B1_Bcol "HASP Plate 02 Page 6 Button 1 BCol [%d]" (HASP_Plate02_Button1_Bcol_Group) {mqtt=">[broker:hasp/plate02/command/p[6].b[1].bco:command:*:default]"}
-Number HASP_Plate02_Button_P7B1_Bcol "HASP Plate 02 Page 7 Button 1 BCol [%d]" (HASP_Plate02_Button1_Bcol_Group) {mqtt=">[broker:hasp/plate02/command/p[7].b[1].bco:command:*:default]"}
-Number HASP_Plate02_Button_P8B1_Bcol "HASP Plate 02 Page 8 Button 1 BCol [%d]" (HASP_Plate02_Button1_Bcol_Group) {mqtt=">[broker:hasp/plate02/command/p[8].b[1].bco:command:*:default]"}
-Number HASP_Plate02_Button_P9B1_Bcol "HASP Plate 02 Page 9 Button 1 BCol [%d]" (HASP_Plate02_Button1_Bcol_Group) {mqtt=">[broker:hasp/plate02/command/p[9].b[1].bco:command:*:default]"}
 
 Switch HASP_Plate02_Button_P1B2 "HASP Plate 02 Page 1 Button 2 State [%s]" (HASP_Plate02_Button2_Group)  {mqtt="<[broker:hasp/plate02/state/p[1].b[2]:state:default]"}
 Switch HASP_Plate02_Button_P2B2 "HASP Plate 02 Page 2 Button 2 State [%s]" (HASP_Plate02_Button2_Group)  {mqtt="<[broker:hasp/plate02/state/p[2].b[2]:state:default]"}
@@ -59,24 +35,6 @@ Switch HASP_Plate02_Button_P6B2 "HASP Plate 02 Page 6 Button 2 State [%s]" (HASP
 Switch HASP_Plate02_Button_P7B2 "HASP Plate 02 Page 7 Button 2 State [%s]" (HASP_Plate02_Button2_Group)  {mqtt="<[broker:hasp/plate02/state/p[7].b[2]:state:default]"}
 Switch HASP_Plate02_Button_P8B2 "HASP Plate 02 Page 8 Button 2 State [%s]" (HASP_Plate02_Button2_Group)  {mqtt="<[broker:hasp/plate02/state/p[8].b[2]:state:default]"}
 Switch HASP_Plate02_Button_P9B2 "HASP Plate 02 Page 9 Button 2 State [%s]" (HASP_Plate02_Button2_Group)  {mqtt="<[broker:hasp/plate02/state/p[9].b[2]:state:default]"}
-String HASP_Plate02_Button_P1B2_Text "HASP Plate 02 Page 1 Button 2 Text [%s]" (HASP_Plate02_Button2_Text_Group) {mqtt=">[broker:hasp/plate02/command/p[1].b[2].txt:command:*:default]"}
-String HASP_Plate02_Button_P2B2_Text "HASP Plate 02 Page 2 Button 2 Text [%s]" (HASP_Plate02_Button2_Text_Group) {mqtt=">[broker:hasp/plate02/command/p[2].b[2].txt:command:*:default]"}
-String HASP_Plate02_Button_P3B2_Text "HASP Plate 02 Page 3 Button 2 Text [%s]" (HASP_Plate02_Button2_Text_Group) {mqtt=">[broker:hasp/plate02/command/p[3].b[2].txt:command:*:default]"}
-String HASP_Plate02_Button_P4B2_Text "HASP Plate 02 Page 4 Button 2 Text [%s]" (HASP_Plate02_Button2_Text_Group) {mqtt=">[broker:hasp/plate02/command/p[4].b[2].txt:command:*:default]"}
-String HASP_Plate02_Button_P5B2_Text "HASP Plate 02 Page 5 Button 2 Text [%s]" (HASP_Plate02_Button2_Text_Group) {mqtt=">[broker:hasp/plate02/command/p[5].b[2].txt:command:*:default]"}
-String HASP_Plate02_Button_P6B2_Text "HASP Plate 02 Page 6 Button 2 Text [%s]" (HASP_Plate02_Button2_Text_Group) {mqtt=">[broker:hasp/plate02/command/p[6].b[2].txt:command:*:default]"}
-String HASP_Plate02_Button_P7B2_Text "HASP Plate 02 Page 7 Button 2 Text [%s]" (HASP_Plate02_Button2_Text_Group) {mqtt=">[broker:hasp/plate02/command/p[7].b[2].txt:command:*:default]"}
-String HASP_Plate02_Button_P8B2_Text "HASP Plate 02 Page 8 Button 2 Text [%s]" (HASP_Plate02_Button2_Text_Group) {mqtt=">[broker:hasp/plate02/command/p[8].b[2].txt:command:*:default]"}
-String HASP_Plate02_Button_P9B2_Text "HASP Plate 02 Page 9 Button 2 Text [%s]" (HASP_Plate02_Button2_Text_Group) {mqtt=">[broker:hasp/plate02/command/p[9].b[2].txt:command:*:default]"}
-Number HASP_Plate02_Button_P1B2_Bcol "HASP Plate 02 Page 1 Button 2 BCol [%d]" (HASP_Plate02_Button2_Bcol_Group) {mqtt=">[broker:hasp/plate02/command/p[1].b[2].bco:command:*:default]"}
-Number HASP_Plate02_Button_P2B2_Bcol "HASP Plate 02 Page 2 Button 2 BCol [%d]" (HASP_Plate02_Button2_Bcol_Group) {mqtt=">[broker:hasp/plate02/command/p[2].b[2].bco:command:*:default]"}
-Number HASP_Plate02_Button_P3B2_Bcol "HASP Plate 02 Page 3 Button 2 BCol [%d]" (HASP_Plate02_Button2_Bcol_Group) {mqtt=">[broker:hasp/plate02/command/p[3].b[2].bco:command:*:default]"}
-Number HASP_Plate02_Button_P4B2_Bcol "HASP Plate 02 Page 4 Button 2 BCol [%d]" (HASP_Plate02_Button2_Bcol_Group) {mqtt=">[broker:hasp/plate02/command/p[4].b[2].bco:command:*:default]"}
-Number HASP_Plate02_Button_P5B2_Bcol "HASP Plate 02 Page 5 Button 2 BCol [%d]" (HASP_Plate02_Button2_Bcol_Group) {mqtt=">[broker:hasp/plate02/command/p[5].b[2].bco:command:*:default]"}
-Number HASP_Plate02_Button_P6B2_Bcol "HASP Plate 02 Page 6 Button 2 BCol [%d]" (HASP_Plate02_Button2_Bcol_Group) {mqtt=">[broker:hasp/plate02/command/p[6].b[2].bco:command:*:default]"}
-Number HASP_Plate02_Button_P7B2_Bcol "HASP Plate 02 Page 7 Button 2 BCol [%d]" (HASP_Plate02_Button2_Bcol_Group) {mqtt=">[broker:hasp/plate02/command/p[7].b[2].bco:command:*:default]"}
-Number HASP_Plate02_Button_P8B2_Bcol "HASP Plate 02 Page 8 Button 2 BCol [%d]" (HASP_Plate02_Button2_Bcol_Group) {mqtt=">[broker:hasp/plate02/command/p[8].b[2].bco:command:*:default]"}
-Number HASP_Plate02_Button_P9B2_Bcol "HASP Plate 02 Page 9 Button 2 BCol [%d]" (HASP_Plate02_Button2_Bcol_Group) {mqtt=">[broker:hasp/plate02/command/p[9].b[2].bco:command:*:default]"}
 
 Switch HASP_Plate02_Button_P1B3 "HASP Plate 02 Page 1 Button 3 State [%s]" (HASP_Plate02_Button3_Group)  {mqtt="<[broker:hasp/plate02/state/p[1].b[3]:state:default]"}
 Switch HASP_Plate02_Button_P2B3 "HASP Plate 02 Page 2 Button 3 State [%s]" (HASP_Plate02_Button3_Group)  {mqtt="<[broker:hasp/plate02/state/p[2].b[3]:state:default]"}
@@ -87,117 +45,45 @@ Switch HASP_Plate02_Button_P6B3 "HASP Plate 02 Page 6 Button 3 State [%s]" (HASP
 Switch HASP_Plate02_Button_P7B3 "HASP Plate 02 Page 7 Button 3 State [%s]" (HASP_Plate02_Button3_Group)  {mqtt="<[broker:hasp/plate02/state/p[7].b[3]:state:default]"}
 Switch HASP_Plate02_Button_P8B3 "HASP Plate 02 Page 8 Button 3 State [%s]" (HASP_Plate02_Button3_Group)  {mqtt="<[broker:hasp/plate02/state/p[8].b[3]:state:default]"}
 Switch HASP_Plate02_Button_P9B3 "HASP Plate 02 Page 9 Button 3 State [%s]" (HASP_Plate02_Button3_Group)  {mqtt="<[broker:hasp/plate02/state/p[9].b[3]:state:default]"}
-String HASP_Plate02_Button_P1B3_Text "HASP Plate 02 Page 1 Button 3 Text [%s]" (HASP_Plate02_Button3_Text_Group) {mqtt=">[broker:hasp/plate02/command/p[1].b[3].txt:command:*:default]"}
-String HASP_Plate02_Button_P2B3_Text "HASP Plate 02 Page 2 Button 3 Text [%s]" (HASP_Plate02_Button3_Text_Group) {mqtt=">[broker:hasp/plate02/command/p[2].b[3].txt:command:*:default]"}
-String HASP_Plate02_Button_P3B3_Text "HASP Plate 02 Page 3 Button 3 Text [%s]" (HASP_Plate02_Button3_Text_Group) {mqtt=">[broker:hasp/plate02/command/p[3].b[3].txt:command:*:default]"}
-String HASP_Plate02_Button_P4B3_Text "HASP Plate 02 Page 4 Button 3 Text [%s]" (HASP_Plate02_Button3_Text_Group) {mqtt=">[broker:hasp/plate02/command/p[4].b[3].txt:command:*:default]"}
-String HASP_Plate02_Button_P5B3_Text "HASP Plate 02 Page 5 Button 3 Text [%s]" (HASP_Plate02_Button3_Text_Group) {mqtt=">[broker:hasp/plate02/command/p[5].b[3].txt:command:*:default]"}
-String HASP_Plate02_Button_P6B3_Text "HASP Plate 02 Page 6 Button 3 Text [%s]" (HASP_Plate02_Button3_Text_Group) {mqtt=">[broker:hasp/plate02/command/p[6].b[3].txt:command:*:default]"}
-String HASP_Plate02_Button_P7B3_Text "HASP Plate 02 Page 7 Button 3 Text [%s]" (HASP_Plate02_Button3_Text_Group) {mqtt=">[broker:hasp/plate02/command/p[7].b[3].txt:command:*:default]"}
-String HASP_Plate02_Button_P8B3_Text "HASP Plate 02 Page 8 Button 3 Text [%s]" (HASP_Plate02_Button3_Text_Group) {mqtt=">[broker:hasp/plate02/command/p[8].b[3].txt:command:*:default]"}
-String HASP_Plate02_Button_P9B3_Text "HASP Plate 02 Page 9 Button 3 Text [%s]" (HASP_Plate02_Button3_Text_Group) {mqtt=">[broker:hasp/plate02/command/p[9].b[3].txt:command:*:default]"}
-Number HASP_Plate02_Button_P1B3_Bcol "HASP Plate 02 Page 1 Button 3 BCol [%d]" (HASP_Plate02_Button3_Bcol_Group) {mqtt=">[broker:hasp/plate02/command/p[1].b[3].bco:command:*:default]"}
-Number HASP_Plate02_Button_P2B3_Bcol "HASP Plate 02 Page 2 Button 3 BCol [%d]" (HASP_Plate02_Button3_Bcol_Group) {mqtt=">[broker:hasp/plate02/command/p[2].b[3].bco:command:*:default]"}
-Number HASP_Plate02_Button_P3B3_Bcol "HASP Plate 02 Page 3 Button 3 BCol [%d]" (HASP_Plate02_Button3_Bcol_Group) {mqtt=">[broker:hasp/plate02/command/p[3].b[3].bco:command:*:default]"}
-Number HASP_Plate02_Button_P4B3_Bcol "HASP Plate 02 Page 4 Button 3 BCol [%d]" (HASP_Plate02_Button3_Bcol_Group) {mqtt=">[broker:hasp/plate02/command/p[4].b[3].bco:command:*:default]"}
-Number HASP_Plate02_Button_P5B3_Bcol "HASP Plate 02 Page 5 Button 3 BCol [%d]" (HASP_Plate02_Button3_Bcol_Group) {mqtt=">[broker:hasp/plate02/command/p[5].b[3].bco:command:*:default]"}
-Number HASP_Plate02_Button_P6B3_Bcol "HASP Plate 02 Page 6 Button 3 BCol [%d]" (HASP_Plate02_Button3_Bcol_Group) {mqtt=">[broker:hasp/plate02/command/p[6].b[3].bco:command:*:default]"}
-Number HASP_Plate02_Button_P7B3_Bcol "HASP Plate 02 Page 7 Button 3 BCol [%d]" (HASP_Plate02_Button3_Bcol_Group) {mqtt=">[broker:hasp/plate02/command/p[7].b[3].bco:command:*:default]"}
-Number HASP_Plate02_Button_P8B3_Bcol "HASP Plate 02 Page 8 Button 3 BCol [%d]" (HASP_Plate02_Button3_Bcol_Group) {mqtt=">[broker:hasp/plate02/command/p[8].b[3].bco:command:*:default]"}
-Number HASP_Plate02_Button_P9B3_Bcol "HASP Plate 02 Page 9 Button 3 BCol [%d]" (HASP_Plate02_Button3_Bcol_Group) {mqtt=">[broker:hasp/plate02/command/p[9].b[3].bco:command:*:default]"}
 
 /* Page 1 Functional Items */
 Switch HASP_Plate02_Button_P1B4 "HASP Plate 02 Page 1 Button 4 State [%s]" (HASP_Plate02_Page1_Button_Group) {mqtt="<[broker:hasp/plate02/state/p[1].b[4]:state:default]"}
 Switch HASP_Plate02_Button_P1B5 "HASP Plate 02 Page 1 Button 5 State [%s]" (HASP_Plate02_Page1_Button_Group) {mqtt="<[broker:hasp/plate02/state/p[1].b[5]:state:default]"}
 Switch HASP_Plate02_Button_P1B6 "HASP Plate 02 Page 1 Button 6 State [%s]" (HASP_Plate02_Page1_Button_Group) {mqtt="<[broker:hasp/plate02/state/p[1].b[6]:state:default]"}
 Switch HASP_Plate02_Button_P1B7 "HASP Plate 02 Page 1 Button 7 State [%s]" (HASP_Plate02_Page1_Button_Group) {mqtt="<[broker:hasp/plate02/state/p[1].b[7]:state:default]"}
-String HASP_Plate02_Button_P1B4_Text "HASP Plate 02 Page 1 Button 4 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[1].b[4].txt:command:*:default]"}
-String HASP_Plate02_Button_P1B5_Text "HASP Plate 02 Page 1 Button 5 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[1].b[5].txt:command:*:default]"}
-String HASP_Plate02_Button_P1B6_Text "HASP Plate 02 Page 1 Button 6 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[1].b[6].txt:command:*:default]"}
-String HASP_Plate02_Button_P1B7_Text "HASP Plate 02 Page 1 Button 7 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[1].b[7].txt:command:*:default]"}
-Number HASP_Plate02_Button_P1B4_Bcol "HASP Plate 02 Page 1 Button 4 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[1].b[4].bco:command:*:default]"}
-Number HASP_Plate02_Button_P1B5_Bcol "HASP Plate 02 Page 1 Button 5 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[1].b[5].bco:command:*:default]"}
-Number HASP_Plate02_Button_P1B6_Bcol "HASP Plate 02 Page 1 Button 6 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[1].b[6].bco:command:*:default]"}
-Number HASP_Plate02_Button_P1B7_Bcol "HASP Plate 02 Page 1 Button 7 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[1].b[7].bco:command:*:default]"}
-Number HASP_Plate02_Button_P1B4_Font "HASP Plate 02 Page 1 Button 4 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[1].b[4].font:command:*:default]"}
-Number HASP_Plate02_Button_P1B5_Font "HASP Plate 02 Page 1 Button 5 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[1].b[5].font:command:*:default]"}
-Number HASP_Plate02_Button_P1B6_Font "HASP Plate 02 Page 1 Button 6 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[1].b[6].font:command:*:default]"}
-Number HASP_Plate02_Button_P1B7_Font "HASP Plate 02 Page 1 Button 7 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[1].b[7].font:command:*:default]"}
 
 /* Page 2 Functional Items */
 Switch HASP_Plate02_Button_P2B4 "HASP Plate 02 Page 2 Button 4 State [%s]" (HASP_Plate02_Page2_Button_Group) {mqtt="<[broker:hasp/plate02/state/p[2].b[4]:state:default]"}
 Switch HASP_Plate02_Button_P2B5 "HASP Plate 02 Page 2 Button 5 State [%s]" (HASP_Plate02_Page2_Button_Group) {mqtt="<[broker:hasp/plate02/state/p[2].b[5]:state:default]"}
 Switch HASP_Plate02_Button_P2B6 "HASP Plate 02 Page 2 Button 6 State [%s]" (HASP_Plate02_Page2_Button_Group) {mqtt="<[broker:hasp/plate02/state/p[2].b[6]:state:default]"}
 Switch HASP_Plate02_Button_P2B7 "HASP Plate 02 Page 2 Button 7 State [%s]" (HASP_Plate02_Page2_Button_Group) {mqtt="<[broker:hasp/plate02/state/p[2].b[7]:state:default]"}
-String HASP_Plate02_Button_P2B4_Text "HASP Plate 02 Page 2 Button 4 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[2].b[4].txt:command:*:default]"}
-String HASP_Plate02_Button_P2B5_Text "HASP Plate 02 Page 2 Button 5 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[2].b[5].txt:command:*:default]"}
-String HASP_Plate02_Button_P2B6_Text "HASP Plate 02 Page 2 Button 6 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[2].b[6].txt:command:*:default]"}
-String HASP_Plate02_Button_P2B7_Text "HASP Plate 02 Page 2 Button 7 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[2].b[7].txt:command:*:default]"}
-Number HASP_Plate02_Button_P2B4_Bcol "HASP Plate 02 Page 2 Button 4 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[2].b[4].bco:command:*:default]"}
-Number HASP_Plate02_Button_P2B5_Bcol "HASP Plate 02 Page 2 Button 5 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[2].b[5].bco:command:*:default]"}
-Number HASP_Plate02_Button_P2B6_Bcol "HASP Plate 02 Page 2 Button 6 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[2].b[6].bco:command:*:default]"}
-Number HASP_Plate02_Button_P2B7_Bcol "HASP Plate 02 Page 2 Button 7 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[2].b[7].bco:command:*:default]"}
-Number HASP_Plate02_Button_P2B4_Font "HASP Plate 02 Page 2 Button 4 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[2].b[4].font:command:*:default]"}
-Number HASP_Plate02_Button_P2B5_Font "HASP Plate 02 Page 2 Button 5 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[2].b[5].font:command:*:default]"}
-Number HASP_Plate02_Button_P2B6_Font "HASP Plate 02 Page 2 Button 6 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[2].b[6].font:command:*:default]"}
-Number HASP_Plate02_Button_P2B7_Font "HASP Plate 02 Page 2 Button 7 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[2].b[7].font:command:*:default]"}
 
 /* Page 3 Functional Items */
 Switch HASP_Plate02_Button_P3B4 "HASP Plate 02 Page 3 Button 4 State [%s]" (HASP_Plate02_Page3_Button_Group) {mqtt="<[broker:hasp/plate02/state/p[3].b[4]:state:default]"}
 Switch HASP_Plate02_Button_P3B5 "HASP Plate 02 Page 3 Button 5 State [%s]" (HASP_Plate02_Page3_Button_Group) {mqtt="<[broker:hasp/plate02/state/p[3].b[5]:state:default]"}
 Switch HASP_Plate02_Button_P3B6 "HASP Plate 02 Page 3 Button 6 State [%s]" (HASP_Plate02_Page3_Button_Group) {mqtt="<[broker:hasp/plate02/state/p[3].b[6]:state:default]"}
 Switch HASP_Plate02_Button_P3B7 "HASP Plate 02 Page 3 Button 7 State [%s]" (HASP_Plate02_Page3_Button_Group) {mqtt="<[broker:hasp/plate02/state/p[3].b[7]:state:default]"}
-String HASP_Plate02_Button_P3B4_Text "HASP Plate 02 Page 3 Button 4 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[3].b[4].txt:command:*:default]"}
-String HASP_Plate02_Button_P3B5_Text "HASP Plate 02 Page 3 Button 5 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[3].b[5].txt:command:*:default]"}
-String HASP_Plate02_Button_P3B6_Text "HASP Plate 02 Page 3 Button 6 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[3].b[6].txt:command:*:default]"}
-String HASP_Plate02_Button_P3B7_Text "HASP Plate 02 Page 3 Button 7 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[3].b[7].txt:command:*:default]"}
-Number HASP_Plate02_Button_P3B4_Bcol "HASP Plate 02 Page 3 Button 4 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[3].b[4].bco:command:*:default]"}
-Number HASP_Plate02_Button_P3B5_Bcol "HASP Plate 02 Page 3 Button 5 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[3].b[5].bco:command:*:default]"}
-Number HASP_Plate02_Button_P3B6_Bcol "HASP Plate 02 Page 3 Button 6 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[3].b[6].bco:command:*:default]"}
-Number HASP_Plate02_Button_P3B7_Bcol "HASP Plate 02 Page 3 Button 7 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[3].b[7].bco:command:*:default]"}
-Number HASP_Plate02_Button_P3B4_Font "HASP Plate 02 Page 3 Button 4 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[3].b[4].font:command:*:default]"}
-Number HASP_Plate02_Button_P3B5_Font "HASP Plate 02 Page 3 Button 5 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[3].b[5].font:command:*:default]"}
-Number HASP_Plate02_Button_P3B6_Font "HASP Plate 02 Page 3 Button 6 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[3].b[6].font:command:*:default]"}
-Number HASP_Plate02_Button_P3B7_Font "HASP Plate 02 Page 3 Button 7 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[3].b[7].font:command:*:default]"}
 
 /* Page 4 Functional Items */
 Switch HASP_Plate02_Button_P4B4 "HASP Plate 02 Page 4 Button 4 State [%s]" (HASP_Plate02_Page4_Button_Group) {mqtt="<[broker:hasp/plate02/state/p[4].b[4]:state:default]"}
 Switch HASP_Plate02_Button_P4B5 "HASP Plate 02 Page 4 Button 5 State [%s]" (HASP_Plate02_Page4_Button_Group) {mqtt="<[broker:hasp/plate02/state/p[4].b[5]:state:default]"}
 Switch HASP_Plate02_Button_P4B6 "HASP Plate 02 Page 4 Button 6 State [%s]" (HASP_Plate02_Page4_Button_Group) {mqtt="<[broker:hasp/plate02/state/p[4].b[6]:state:default]"}
-String HASP_Plate02_Button_P4B4_Text "HASP Plate 02 Page 4 Button 4 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[4].b[4].txt:command:*:default]"}
-String HASP_Plate02_Button_P4B5_Text "HASP Plate 02 Page 4 Button 5 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[4].b[5].txt:command:*:default]"}
-String HASP_Plate02_Button_P4B6_Text "HASP Plate 02 Page 4 Button 6 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[4].b[6].txt:command:*:default]"}
-Number HASP_Plate02_Button_P4B4_Bcol "HASP Plate 02 Page 4 Button 4 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[4].b[4].bco:command:*:default]"}
-Number HASP_Plate02_Button_P4B5_Bcol "HASP Plate 02 Page 4 Button 5 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[4].b[5].bco:command:*:default]"}
-Number HASP_Plate02_Button_P4B6_Bcol "HASP Plate 02 Page 4 Button 6 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[4].b[6].bco:command:*:default]"}
-Number HASP_Plate02_Button_P4B4_Font "HASP Plate 02 Page 4 Button 4 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[4].b[4].font:command:*:default]"}
-Number HASP_Plate02_Button_P4B5_Font "HASP Plate 02 Page 4 Button 5 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[4].b[5].font:command:*:default]"}
-Number HASP_Plate02_Button_P4B6_Font "HASP Plate 02 Page 4 Button 6 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[4].b[6].font:command:*:default]"}
 Number HASP_Plate02_Dimmer_P4B7 "HASP Plate 02 Page 4 Dimmer 7 State [%d]" (HASP_Plate02_Page4_Dimmer_Group) {mqtt="<[broker:hasp/plate02/state/p[4].b[7].val:state:default]"}
 Number HASP_Plate02_Dimmer_P4B7_Val "HASP Plate 02 Page 4 Dimmer 7 Value" {mqtt=">[broker:hasp/plate02/command/p[4].b[7].val:command:*:default]"}
-Number HASP_Plate02_Dimmer_P4B8 "HASP Plate 02 Page 4 Dimmer 8 State [%d]" (HASP_Plate02_Page4_Dimmer_Group) {mqtt="<[broker:hasp/plate02/state/p[4].b[8].val:state:default]"}//",>[broker:hasp/plate02/command/p[4].b[8].val:command:*:default]"}
+Number HASP_Plate02_Dimmer_P4B8 "HASP Plate 02 Page 4 Dimmer 8 State [%d]" (HASP_Plate02_Page4_Dimmer_Group) {mqtt="<[broker:hasp/plate02/state/p[4].b[8].val:state:default]"}
 Number HASP_Plate02_Dimmer_P4B8_Val "HASP Plate 02 Page 4 Dimmer 8 Value" {mqtt=">[broker:hasp/plate02/command/p[4].b[8].val:command:*:default]"}
-Number HASP_Plate02_Dimmer_P4B9 "HASP Plate 02 Page 4 Dimmer 9 State [%d]" (HASP_Plate02_Page4_Dimmer_Group) {mqtt="<[broker:hasp/plate02/state/p[4].b[9].val:state:default]"}//",>[broker:hasp/plate02/command/p[4].b[9].val:command:*:default]"}
+Number HASP_Plate02_Dimmer_P4B9 "HASP Plate 02 Page 4 Dimmer 9 State [%d]" (HASP_Plate02_Page4_Dimmer_Group) {mqtt="<[broker:hasp/plate02/state/p[4].b[9].val:state:default]"}
 Number HASP_Plate02_Dimmer_P4B9_Val "HASP Plate 02 Page 4 Dimmer 9 Value" {mqtt=">[broker:hasp/plate02/command/p[4].b[9].val:command:*:default]"}
 
 /* Page 5 Functional Items */
 Switch HASP_Plate02_Button_P5B4 "HASP Plate 02 Page 5 Button 4 State [%s]" (HASP_Plate02_Page5_Button_Group) {mqtt="<[broker:hasp/plate02/state/p[5].b[4]:state:default]"}
 Switch HASP_Plate02_Button_P5B5 "HASP Plate 02 Page 5 Button 5 State [%s]" (HASP_Plate02_Page5_Button_Group) {mqtt="<[broker:hasp/plate02/state/p[5].b[5]:state:default]"}
 Switch HASP_Plate02_Button_P5B6 "HASP Plate 02 Page 5 Button 6 State [%s]" (HASP_Plate02_Page5_Button_Group) {mqtt="<[broker:hasp/plate02/state/p[5].b[6]:state:default]"}
-String HASP_Plate02_Button_P5B4_Text "HASP Plate 02 Page 5 Button 4 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[5].b[4].txt:command:*:default]"}
-String HASP_Plate02_Button_P5B5_Text "HASP Plate 02 Page 5 Button 5 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[5].b[5].txt:command:*:default]"}
-String HASP_Plate02_Button_P5B6_Text "HASP Plate 02 Page 5 Button 6 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[5].b[6].txt:command:*:default]"}
-Number HASP_Plate02_Button_P5B4_Bcol "HASP Plate 02 Page 5 Button 4 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[5].b[4].bco:command:*:default]"}
-Number HASP_Plate02_Button_P5B5_Bcol "HASP Plate 02 Page 5 Button 5 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[5].b[5].bco:command:*:default]"}
-Number HASP_Plate02_Button_P5B6_Bcol "HASP Plate 02 Page 5 Button 6 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[5].b[6].bco:command:*:default]"}
-Number HASP_Plate02_Button_P5B4_Font "HASP Plate 02 Page 5 Button 4 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[5].b[4].font:command:*:default]"}
-Number HASP_Plate02_Button_P5B5_Font "HASP Plate 02 Page 5 Button 5 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[5].b[5].font:command:*:default]"}
-Number HASP_Plate02_Button_P5B6_Font "HASP Plate 02 Page 5 Button 6 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[5].b[6].font:command:*:default]"}
-Number HASP_Plate02_Dimmer_P5B7 "HASP Plate 02 Page 5 Dimmer 7 State [%d]" (HASP_Plate02_Page5_Dimmer_Group) {mqtt="<[broker:hasp/plate02/state/p[5].b[7].val:state:default]"}//",>[broker:hasp/plate02/command/p[5].b[7].val:command:*:default]"}
+Number HASP_Plate02_Dimmer_P5B7 "HASP Plate 02 Page 5 Dimmer 7 State [%d]" (HASP_Plate02_Page5_Dimmer_Group) {mqtt="<[broker:hasp/plate02/state/p[5].b[7].val:state:default]"}
 Number HASP_Plate02_Dimmer_P5B7_Val "HASP Plate 02 Page 5 Dimmer 7 Value" {mqtt=">[broker:hasp/plate02/command/p[5].b[7].val:command:*:default]"}
-Number HASP_Plate02_Dimmer_P5B8 "HASP Plate 02 Page 5 Dimmer 8 State [%d]" (HASP_Plate02_Page5_Dimmer_Group) {mqtt="<[broker:hasp/plate02/state/p[5].b[8].val:state:default]"}//",>[broker:hasp/plate02/command/p[5].b[8].val:command:*:default]"}
+Number HASP_Plate02_Dimmer_P5B8 "HASP Plate 02 Page 5 Dimmer 8 State [%d]" (HASP_Plate02_Page5_Dimmer_Group) {mqtt="<[broker:hasp/plate02/state/p[5].b[8].val:state:default]"}
 Number HASP_Plate02_Dimmer_P5B8_Val "HASP Plate 02 Page 5 Dimmer 8 Value" {mqtt=">[broker:hasp/plate02/command/p[5].b[8].val:command:*:default]"}
-Number HASP_Plate02_Dimmer_P5B9 "HASP Plate 02 Page 5 Dimmer 9 State [%d]" (HASP_Plate02_Page5_Dimmer_Group) {mqtt="<[broker:hasp/plate02/state/p[5].b[9].val:state:default]"}//",>[broker:hasp/plate02/command/p[5].b[9].val:command:*:default]"}
+Number HASP_Plate02_Dimmer_P5B9 "HASP Plate 02 Page 5 Dimmer 9 State [%d]" (HASP_Plate02_Page5_Dimmer_Group) {mqtt="<[broker:hasp/plate02/state/p[5].b[9].val:state:default]"}
 Number HASP_Plate02_Dimmer_P5B9_Val "HASP Plate 02 Page 5 Dimmer 9 Value" {mqtt=">[broker:hasp/plate02/command/p[5].b[9].val:command:*:default]"}
 
 /* Page 6 Functional Items */
@@ -209,30 +95,6 @@ Switch HASP_Plate02_Button_P6B8 "HASP Plate 02 Page 6 Button 8 State [%s]" (HASP
 Switch HASP_Plate02_Button_P6B9 "HASP Plate 02 Page 6 Button 9 State [%s]" (HASP_Plate02_Page6_Button_Group) {mqtt="<[broker:hasp/plate02/state/p[6].b[9]:state:default]"}
 Switch HASP_Plate02_Button_P6B10 "HASP Plate 02 Page 6 Button 10 State [%s]" (HASP_Plate02_Page6_Button_Group) {mqtt="<[broker:hasp/plate02/state/p[6].b[10]:state:default]"}
 Switch HASP_Plate02_Button_P6B11 "HASP Plate 02 Page 6 Button 11 State [%s]" (HASP_Plate02_Page6_Button_Group) {mqtt="<[broker:hasp/plate02/state/p[6].b[11]:state:default]"}
-String HASP_Plate02_Button_P6B4_Text "HASP Plate 02 Page 6 Button 4 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[6].b[4].txt:command:*:default]"}
-String HASP_Plate02_Button_P6B5_Text "HASP Plate 02 Page 6 Button 5 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[6].b[5].txt:command:*:default]"}
-String HASP_Plate02_Button_P6B6_Text "HASP Plate 02 Page 6 Button 6 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[6].b[6].txt:command:*:default]"}
-String HASP_Plate02_Button_P6B7_Text "HASP Plate 02 Page 6 Button 7 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[6].b[7].txt:command:*:default]"}
-String HASP_Plate02_Button_P6B8_Text "HASP Plate 02 Page 6 Button 8 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[6].b[8].txt:command:*:default]"}
-String HASP_Plate02_Button_P6B9_Text "HASP Plate 02 Page 6 Button 9 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[6].b[9].txt:command:*:default]"}
-String HASP_Plate02_Button_P6B10_Text "HASP Plate 02 Page 6 Button 10 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[6].b[10].txt:command:*:default]"}
-String HASP_Plate02_Button_P6B11_Text "HASP Plate 02 Page 6 Button 11 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[6].b[11].txt:command:*:default]"}
-Number HASP_Plate02_Button_P6B4_Bcol "HASP Plate 02 Page 6 Button 4 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[6].b[4].bco:command:*:default]"}
-Number HASP_Plate02_Button_P6B5_Bcol "HASP Plate 02 Page 6 Button 5 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[6].b[5].bco:command:*:default]"}
-Number HASP_Plate02_Button_P6B6_Bcol "HASP Plate 02 Page 6 Button 6 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[6].b[6].bco:command:*:default]"}
-Number HASP_Plate02_Button_P6B7_Bcol "HASP Plate 02 Page 6 Button 7 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[6].b[7].bco:command:*:default]"}
-Number HASP_Plate02_Button_P6B8_Bcol "HASP Plate 02 Page 6 Button 8 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[6].b[8].bco:command:*:default]"}
-Number HASP_Plate02_Button_P6B9_Bcol "HASP Plate 02 Page 6 Button 9 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[6].b[9].bco:command:*:default]"}
-Number HASP_Plate02_Button_P6B10_Bcol "HASP Plate 02 Page 6 Button 10 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[6].b[10].bco:command:*:default]"}
-Number HASP_Plate02_Button_P6B11_Bcol "HASP Plate 02 Page 6 Button 11 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[6].b[11].bco:command:*:default]"}
-Number HASP_Plate02_Button_P6B4_Font "HASP Plate 02 Page 6 Button 4 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[6].b[4].font:command:*:default]"}
-Number HASP_Plate02_Button_P6B5_Font "HASP Plate 02 Page 6 Button 5 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[6].b[5].font:command:*:default]"}
-Number HASP_Plate02_Button_P6B6_Font "HASP Plate 02 Page 6 Button 6 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[6].b[6].font:command:*:default]"}
-Number HASP_Plate02_Button_P6B7_Font "HASP Plate 02 Page 6 Button 7 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[6].b[7].font:command:*:default]"}
-Number HASP_Plate02_Button_P6B8_Font "HASP Plate 02 Page 6 Button 8 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[6].b[8].font:command:*:default]"}
-Number HASP_Plate02_Button_P6B9_Font "HASP Plate 02 Page 6 Button 9 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[6].b[9].font:command:*:default]"}
-Number HASP_Plate02_Button_P6B10_Font "HASP Plate 02 Page 6 Button 10 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[6].b[10].font:command:*:default]"}
-Number HASP_Plate02_Button_P6B11_Font "HASP Plate 02 Page 6 Button 11 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[6].b[11].font:command:*:default]"}
 
 /* Page 7 Functional Items */
 Switch HASP_Plate02_Button_P7B4 "HASP Plate 02 Page 7 Button 4 State [%s]" (HASP_Plate02_Page7_Button_Group) {mqtt="<[broker:hasp/plate02/state/p[7].b[4]:state:default]"}
@@ -247,42 +109,6 @@ Switch HASP_Plate02_Button_P7B12 "HASP Plate 02 Page 7 Button 12 State [%s]" (HA
 Switch HASP_Plate02_Button_P7B13 "HASP Plate 02 Page 7 Button 13 State [%s]" (HASP_Plate02_Page7_Button_Group) {mqtt="<[broker:hasp/plate02/state/p[7].b[13]:state:default]"}
 Switch HASP_Plate02_Button_P7B14 "HASP Plate 02 Page 7 Button 14 State [%s]" (HASP_Plate02_Page7_Button_Group) {mqtt="<[broker:hasp/plate02/state/p[7].b[14]:state:default]"}
 Switch HASP_Plate02_Button_P7B15 "HASP Plate 02 Page 7 Button 15 State [%s]" (HASP_Plate02_Page7_Button_Group) {mqtt="<[broker:hasp/plate02/state/p[7].b[15]:state:default]"}
-String HASP_Plate02_Button_P7B4_Text "HASP Plate 02 Page 7 Button 4 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[7].b[4].txt:command:*:default]"}
-String HASP_Plate02_Button_P7B5_Text "HASP Plate 02 Page 7 Button 5 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[7].b[5].txt:command:*:default]"}
-String HASP_Plate02_Button_P7B6_Text "HASP Plate 02 Page 7 Button 6 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[7].b[6].txt:command:*:default]"}
-String HASP_Plate02_Button_P7B7_Text "HASP Plate 02 Page 7 Button 7 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[7].b[7].txt:command:*:default]"}
-String HASP_Plate02_Button_P7B8_Text "HASP Plate 02 Page 7 Button 8 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[7].b[8].txt:command:*:default]"}
-String HASP_Plate02_Button_P7B9_Text "HASP Plate 02 Page 7 Button 9 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[7].b[9].txt:command:*:default]"}
-String HASP_Plate02_Button_P7B10_Text "HASP Plate 02 Page 7 Button 10 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[7].b[10].txt:command:*:default]"}
-String HASP_Plate02_Button_P7B11_Text "HASP Plate 02 Page 7 Button 11 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[7].b[11].txt:command:*:default]"}
-String HASP_Plate02_Button_P7B12_Text "HASP Plate 02 Page 7 Button 12 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[7].b[12].txt:command:*:default]"}
-String HASP_Plate02_Button_P7B13_Text "HASP Plate 02 Page 7 Button 13 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[7].b[13].txt:command:*:default]"}
-String HASP_Plate02_Button_P7B14_Text "HASP Plate 02 Page 7 Button 14 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[7].b[14].txt:command:*:default]"}
-String HASP_Plate02_Button_P7B15_Text "HASP Plate 02 Page 7 Button 15 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[7].b[15].txt:command:*:default]"}
-Number HASP_Plate02_Button_P7B4_Bcol "HASP Plate 02 Page 7 Button 4 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[7].b[4].bco:command:*:default]"}
-Number HASP_Plate02_Button_P7B5_Bcol "HASP Plate 02 Page 7 Button 5 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[7].b[5].bco:command:*:default]"}
-Number HASP_Plate02_Button_P7B6_Bcol "HASP Plate 02 Page 7 Button 6 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[7].b[6].bco:command:*:default]"}
-Number HASP_Plate02_Button_P7B7_Bcol "HASP Plate 02 Page 7 Button 7 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[7].b[7].bco:command:*:default]"}
-Number HASP_Plate02_Button_P7B8_Bcol "HASP Plate 02 Page 7 Button 8 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[7].b[8].bco:command:*:default]"}
-Number HASP_Plate02_Button_P7B9_Bcol "HASP Plate 02 Page 7 Button 9 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[7].b[9].bco:command:*:default]"}
-Number HASP_Plate02_Button_P7B10_Bcol "HASP Plate 02 Page 7 Button 10 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[7].b[10].bco:command:*:default]"}
-Number HASP_Plate02_Button_P7B11_Bcol "HASP Plate 02 Page 7 Button 11 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[7].b[11].bco:command:*:default]"}
-Number HASP_Plate02_Button_P7B12_Bcol "HASP Plate 02 Page 7 Button 12 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[7].b[12].bco:command:*:default]"}
-Number HASP_Plate02_Button_P7B13_Bcol "HASP Plate 02 Page 7 Button 13 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[7].b[13].bco:command:*:default]"}
-Number HASP_Plate02_Button_P7B14_Bcol "HASP Plate 02 Page 7 Button 14 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[7].b[14].bco:command:*:default]"}
-Number HASP_Plate02_Button_P7B15_Bcol "HASP Plate 02 Page 7 Button 15 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[7].b[15].bco:command:*:default]"}
-Number HASP_Plate02_Button_P7B4_Font "HASP Plate 02 Page 7 Button 4 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[7].b[4].font:command:*:default]"}
-Number HASP_Plate02_Button_P7B5_Font "HASP Plate 02 Page 7 Button 5 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[7].b[5].font:command:*:default]"}
-Number HASP_Plate02_Button_P7B6_Font "HASP Plate 02 Page 7 Button 6 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[7].b[6].font:command:*:default]"}
-Number HASP_Plate02_Button_P7B7_Font "HASP Plate 02 Page 7 Button 7 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[7].b[7].font:command:*:default]"}
-Number HASP_Plate02_Button_P7B8_Font "HASP Plate 02 Page 7 Button 8 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[7].b[8].font:command:*:default]"}
-Number HASP_Plate02_Button_P7B9_Font "HASP Plate 02 Page 7 Button 9 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[7].b[9].font:command:*:default]"}
-Number HASP_Plate02_Button_P7B10_Font "HASP Plate 02 Page 7 Button 10 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[7].b[10].font:command:*:default]"}
-Number HASP_Plate02_Button_P7B11_Font "HASP Plate 02 Page 7 Button 11 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[7].b[11].font:command:*:default]"}
-Number HASP_Plate02_Button_P7B12_Font "HASP Plate 02 Page 7 Button 12 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[7].b[12].font:command:*:default]"}
-Number HASP_Plate02_Button_P7B13_Font "HASP Plate 02 Page 7 Button 13 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[7].b[13].font:command:*:default]"}
-Number HASP_Plate02_Button_P7B14_Font "HASP Plate 02 Page 7 Button 14 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[7].b[14].font:command:*:default]"}
-Number HASP_Plate02_Button_P7B15_Font "HASP Plate 02 Page 7 Button 15 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[7].b[15].font:command:*:default]"}
 
 /* Page 8 Functional Items */
 Switch HASP_Plate02_Button_P8B4 "HASP Plate 02 Page 8 Button 4 State [%s]" (HASP_Plate02_Page8_Button_Group) {mqtt="<[broker:hasp/plate02/state/p[8].b[4]:state:default]"}
@@ -290,34 +116,12 @@ Switch HASP_Plate02_Button_P8B5 "HASP Plate 02 Page 8 Button 5 State [%s]" (HASP
 Switch HASP_Plate02_Button_P8B6 "HASP Plate 02 Page 8 Button 6 State [%s]" (HASP_Plate02_Page8_Button_Group) {mqtt="<[broker:hasp/plate02/state/p[8].b[6]:state:default]"}
 Switch HASP_Plate02_Button_P8B7 "HASP Plate 02 Page 8 Button 7 State [%s]" (HASP_Plate02_Page8_Button_Group) {mqtt="<[broker:hasp/plate02/state/p[8].b[7]:state:default]"}
 Switch HASP_Plate02_Button_P8B8 "HASP Plate 02 Page 8 Button 8 State [%s]" (HASP_Plate02_Page8_Button_Group) {mqtt="<[broker:hasp/plate02/state/p[8].b[8]:state:default]"}
-String HASP_Plate02_Button_P8B4_Text "HASP Plate 02 Page 8 Button 4 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[8].b[4].txt:command:*:default]"}
-String HASP_Plate02_Button_P8B5_Text "HASP Plate 02 Page 8 Button 5 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[8].b[5].txt:command:*:default]"}
-String HASP_Plate02_Button_P8B6_Text "HASP Plate 02 Page 8 Button 6 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[8].b[6].txt:command:*:default]"}
-String HASP_Plate02_Button_P8B7_Text "HASP Plate 02 Page 8 Button 7 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[8].b[7].txt:command:*:default]"}
-String HASP_Plate02_Button_P8B8_Text "HASP Plate 02 Page 8 Button 8 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[8].b[8].txt:command:*:default]"}
-Number HASP_Plate02_Button_P8B4_Bcol "HASP Plate 02 Page 8 Button 4 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[8].b[4].bco:command:*:default]"}
-Number HASP_Plate02_Button_P8B5_Bcol "HASP Plate 02 Page 8 Button 5 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[8].b[5].bco:command:*:default]"}
-Number HASP_Plate02_Button_P8B6_Bcol "HASP Plate 02 Page 8 Button 6 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[8].b[6].bco:command:*:default]"}
-Number HASP_Plate02_Button_P8B7_Bcol "HASP Plate 02 Page 8 Button 7 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[8].b[7].bco:command:*:default]"}
-Number HASP_Plate02_Button_P8B8_Bcol "HASP Plate 02 Page 8 Button 8 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[8].b[8].bco:command:*:default]"}
-Number HASP_Plate02_Button_P8B4_Font "HASP Plate 02 Page 8 Button 4 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[8].b[4].font:command:*:default]"}
-Number HASP_Plate02_Button_P8B5_Font "HASP Plate 02 Page 8 Button 5 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[8].b[5].font:command:*:default]"}
-Number HASP_Plate02_Button_P8B6_Font "HASP Plate 02 Page 8 Button 6 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[8].b[6].font:command:*:default]"}
-Number HASP_Plate02_Button_P8B7_Font "HASP Plate 02 Page 8 Button 7 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[8].b[7].font:command:*:default]"}
-Number HASP_Plate02_Button_P8B8_Font "HASP Plate 02 Page 8 Button 8 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[8].b[8].font:command:*:default]"}
 Number HASP_Plate02_Dimmer_P8B9 "HASP Plate 02 Page 8 Dimmer 9 State [%d]" (HASP_Plate02_Page8_Dimmer_Group) {mqtt="<[broker:hasp/plate02/state/p[8].b[9].val:state:default]"}
 Number HASP_Plate02_Dimmer_P8B9_Val "HASP Plate 02 Page 8 Dimmer 9 Value" {mqtt=">[broker:hasp/plate02/command/p[8].b[9].val:command:*:default]"}
 
 /* Page 9 Functional Items */
 Switch HASP_Plate02_Button_P9B4 "HASP Plate 02 Page 9 Button 4 State [%s]" (HASP_Plate02_Page9_Button_Group) {mqtt="<[broker:hasp/plate02/state/p[9].b[4]:state:default]"}
 Switch HASP_Plate02_Button_P9B5 "HASP Plate 02 Page 9 Button 5 State [%s]" (HASP_Plate02_Page9_Button_Group) {mqtt="<[broker:hasp/plate02/state/p[9].b[5]:state:default]"}
-String HASP_Plate02_Button_P9B4_Text "HASP Plate 02 Page 9 Button 4 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[9].b[4].txt:command:*:default]"}
-String HASP_Plate02_Button_P9B5_Text "HASP Plate 02 Page 9 Button 5 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[9].b[5].txt:command:*:default]"}
-String HASP_Plate02_Button_P9B6_Text "HASP Plate 02 Page 9 Button 6 Text [%s]" {mqtt=">[broker:hasp/plate02/command/p[9].b[6].txt:command:*:default]"}
-Number HASP_Plate02_Button_P9B4_Bcol "HASP Plate 02 Page 9 Button 4 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[9].b[4].bco:command:*:default]"}
-Number HASP_Plate02_Button_P9B5_Bcol "HASP Plate 02 Page 9 Button 5 Bcol [%d]" {mqtt=">[broker:hasp/plate02/command/p[9].b[5].bco:command:*:default]"}
-Number HASP_Plate02_Button_P9B4_Font "HASP Plate 02 Page 9 Button 4 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[9].b[4].font:command:*:default]"}
-Number HASP_Plate02_Button_P9B5_Font "HASP Plate 02 Page 9 Button 5 Font [%d]" {mqtt=">[broker:hasp/plate02/command/p[9].b[5].font:command:*:default]"}
 
 /* Page Storage Items */
 
@@ -341,6 +145,8 @@ String HASP_Plate02_Plate_Sensor_LCDUpdate "HASP Plate 02 Sensor - LCD Update Av
 Number HASP_Plate02_Plate_Sensor_ESPUptime "HASP Plate 02 Sensor - ESP Uptime [%d secs]" (HASP) {mqtt="<[broker:hasp/plate02/sensor:state:JSONPATH($.espUptime)]"}
 Number HASP_Plate02_Plate_Sensor_SignalStrength "HASP Plate 02 Sensor - Signal Strength [%d dbm]" (HASP) {mqtt="<[broker:hasp/plate02/sensor:state:JSONPATH($.signalStrength)]"}
 String HASP_Plate02_Plate_Sensor_HaspIP "HASP Plate 02 Sensor - HASP IP [%s]" (HASP) {mqtt="<[broker:hasp/plate02/sensor:state:JSONPATH($.haspIP)]"}
+
+Switch HASP_Plate02_Plate_Refresh "HASP Plate 02 Refresh" (HASP) {expire="10s,command=OFF"}
 
 Number HASP_Plate02_Plate_Motion "HASP Plate 02 Motion Status [%d]" (HASP) {mqtt="<[broker:hasp/plate02/motion/state:state:default]"}
 

--- a/contrib/openHAB/HASP-Foyer.rules
+++ b/contrib/openHAB/HASP-Foyer.rules
@@ -4,67 +4,67 @@
 
 /* Configuration for the three page selection buttons at the bottom of the page */
 val plate02_pagebutton1page = 1 // Set page # for bottom left button
-val plate02_pagebutton1txt = '"Scenes"' // Set page title for bottom left button
+val plate02_pagebutton1txt = 'Scenes' // Set page title for bottom left button
 val plate02_pagebutton2page = 2 // Set page # for bottom center button
-val plate02_pagebutton2txt = '"Status"' // Set page title for bottom left button
+val plate02_pagebutton2txt = 'Status' // Set page title for bottom left button
 val plate02_pagebutton3page = 6 // Set page # for bottom right button
-val plate02_pagebutton3txt = '"HVAC"' // Set page title for bottom left button
+val plate02_pagebutton3txt = 'HVAC' // Set page title for bottom left button
 
 /* Configuration for page 1 (Scenes) */
-val plate02_page1button4txt = '"Morning"'
-val plate02_page1button5txt = '"Evening"'
-val plate02_page1button6txt = '"Night"'
-val plate02_page1button7txt = '"Bedtime"'
+val plate02_page1button4txt = 'Morning'
+val plate02_page1button5txt = 'Evening'
+val plate02_page1button6txt = 'Night'
+val plate02_page1button7txt = 'Bedtime'
 val plate02_page1button4font = 2
 val plate02_page1button5font = 2
 val plate02_page1button6font = 2
 val plate02_page1button7font = 2
 
 /* Configuration for page 2 (Status) */
-val plate02_page2button4txt = '"Line 1"'
-val plate02_page2button5txt = '"Line 2"'
-val plate02_page2button6txt = '"Line 3"'
-val plate02_page2button7txt = '"Line 4"'
+val plate02_page2button4txt = 'Line 1'
+val plate02_page2button5txt = 'Line 2'
+val plate02_page2button6txt = 'Line 3'
+val plate02_page2button7txt = 'Line 4'
 val plate02_page2button4font = 2
 val plate02_page2button5font = 2
 val plate02_page2button6font = 2
 val plate02_page2button7font = 1
 
 /* Configuration for page 3 (Page 3) */
-val plate02_page3button4txt = '"P3 B4 Text"'
-val plate02_page3button5txt = '"P3 B5 Text"'
-val plate02_page3button6txt = '"P3 B6 Text"'
-val plate02_page3button7txt = '"P3 B7 Text"'
+val plate02_page3button4txt = 'P3 B4 Text'
+val plate02_page3button5txt = 'P3 B5 Text'
+val plate02_page3button6txt = 'P3 B6 Text'
+val plate02_page3button7txt = 'P3 B7 Text'
 val plate02_page3button4font = 1
 val plate02_page3button5font = 1
 val plate02_page3button6font = 1
 val plate02_page3button7font = 1
 
 /* Configuration for page 4 (Page 4) */
-val plate02_page4button4txt = '"P4 B4 Light"'
-val plate02_page4button5txt = '"P4 B5 Light"'
-val plate02_page4button6txt = '"P4 B6 Light"'
+val plate02_page4button4txt = 'P4 B4 Light'
+val plate02_page4button5txt = 'P4 B5 Light'
+val plate02_page4button6txt = 'P4 B6 Light'
 val plate02_page4button4font = 1
 val plate02_page4button5font = 1
 val plate02_page4button6font = 1
 
 /* Configuration for page 5 (Page 5) */
-val plate02_page5button4txt = '"P5 B4 Light"'
-val plate02_page5button5txt = '"P5 B5 Light"'
-val plate02_page5button6txt = '"P5 B6 Light"'
+val plate02_page5button4txt = 'P5 B4 Light'
+val plate02_page5button5txt = 'P5 B5 Light'
+val plate02_page5button6txt = 'P5 B6 Light'
 val plate02_page5button4font = 1
 val plate02_page5button5font = 1
 val plate02_page5button6font = 1
 
 /* Configuration for page 6 (HVAC) */
-val plate02_page6button4txt = '"P6 B4"'
-val plate02_page6button5txt = '"P6 B5"'
-val plate02_page6button6txt = '"P6 B6"'
-val plate02_page6button7txt = '"P6 B7"'
-val plate02_page6button8txt = '"P6 B8"'
-val plate02_page6button9txt = '"P6 B9"'
-val plate02_page6button10txt = '"P6 B10"'
-val plate02_page6button11txt = '"P6 B11"'
+val plate02_page6button4txt = 'P6 B4'
+val plate02_page6button5txt = 'P6 B5'
+val plate02_page6button6txt = 'P6 B6'
+val plate02_page6button7txt = 'P6 B7'
+val plate02_page6button8txt = 'P6 B8'
+val plate02_page6button9txt = 'P6 B9'
+val plate02_page6button10txt = 'P6 B10'
+val plate02_page6button11txt = 'P6 B11'
 val plate02_page6button4font = 1
 val plate02_page6button5font = 1
 val plate02_page6button6font = 1
@@ -75,18 +75,18 @@ val plate02_page6button10font = 1
 val plate02_page6button11font = 1
 
 /* Configuration for page 7 (Page 7) */
-val plate02_page7button4txt = '"1"'
-val plate02_page7button5txt = '"2"'
-val plate02_page7button6txt = '"3"'
-val plate02_page7button7txt = '"4"'
-val plate02_page7button8txt = '"5"'
-val plate02_page7button9txt = '"6"'
-val plate02_page7button10txt = '"7"'
-val plate02_page7button11txt = '"8"'
-val plate02_page7button12txt = '"9"'
-val plate02_page7button13txt = '"*"'
-val plate02_page7button14txt = '"0"'
-val plate02_page7button15txt = '"#"'
+val plate02_page7button4txt = '1'
+val plate02_page7button5txt = '2'
+val plate02_page7button6txt = '3'
+val plate02_page7button7txt = '4'
+val plate02_page7button8txt = '5'
+val plate02_page7button9txt = '6'
+val plate02_page7button10txt = '7'
+val plate02_page7button11txt = '8'
+val plate02_page7button12txt = '9'
+val plate02_page7button13txt = '*'
+val plate02_page7button14txt = '0'
+val plate02_page7button15txt = '#'
 val plate02_page7button4font = 3
 val plate02_page7button5font = 3
 val plate02_page7button6font = 3
@@ -101,11 +101,11 @@ val plate02_page7button14font = 3
 val plate02_page7button15font = 3
 
 /* Configuration for page 8 (Page 8) */
-val plate02_page8button4txt = '"P8 B4"'
-val plate02_page8button5txt = '"P8 B5"'
-val plate02_page8button6txt = '"P8B6"'
-val plate02_page8button7txt = '"P8B7"'
-val plate02_page8button8txt = '"P8B8"'
+val plate02_page8button4txt = 'P8 B4'
+val plate02_page8button5txt = 'P8 B5'
+val plate02_page8button6txt = 'P8B6'
+val plate02_page8button7txt = 'P8B7'
+val plate02_page8button8txt = 'P8B8'
 val plate02_page8button4font = 1
 val plate02_page8button5font = 1
 val plate02_page8button6font = 1
@@ -113,8 +113,8 @@ val plate02_page8button7font = 1
 val plate02_page8button8font = 1
 
 /* Configuration for page 9 (Page 9) */
-val plate02_page9button4txt = '"P9 B4"'
-val plate02_page9button5txt = '"P9 B5"'
+val plate02_page9button4txt = 'P9 B4'
+val plate02_page9button5txt = 'P9 B5'
 val plate02_page9button4font = 2
 val plate02_page9button5font = 2
 
@@ -594,126 +594,165 @@ end
 /* Restore saved page and rebuild config on reconnect */
 rule "HASP Foyer Restore page on connect"
 when
-    Item HASP_Plate02_Plate_Sensor_Status changed to "available"
+    Item HASP_Plate02_Plate_Sensor_Status changed to "available" or
+    Item HASP_Plate02_Plate_Refresh received command ON
 then
   
     HASP_Plate02_Page.sendCommand(HASP_Plate02_Page_Current.state as Number) // Send HASP to previous page
 
-    HASP_Plate02_Button1_Bcol_Group.sendCommand("25388") // Initialize page buttons with gray color
-    HASP_Plate02_Button2_Bcol_Group.sendCommand("25388")
-    HASP_Plate02_Button3_Bcol_Group.sendCommand("25388")
-    HASP_Plate02_Button1_Text_Group.sendCommand(plate02_pagebutton1txt) // Set bottom page buttons text
-    HASP_Plate02_Button2_Text_Group.sendCommand(plate02_pagebutton2txt)
-    HASP_Plate02_Button3_Text_Group.sendCommand(plate02_pagebutton3txt)
+    var jsonString = '["p[1].b[1].bco=25388", ' +   //Initialize bottom page buttons with gray color
+                    '"p[1].b[2].bco=25388", ' +
+                    '"p[1].b[3].bco=25388", ' +
+                    '"p[2].b[1].bco=25388", ' +
+                    '"p[2].b[2].bco=25388", ' +
+                    '"p[2].b[3].bco=25388", ' +
+                    '"p[3].b[1].bco=25388", ' +
+                    '"p[3].b[2].bco=25388", ' +
+                    '"p[3].b[3].bco=25388", ' +
+                    '"p[4].b[1].bco=25388", ' +
+                    '"p[4].b[2].bco=25388", ' +
+                    '"p[4].b[3].bco=25388", ' +
+                    '"p[5].b[1].bco=25388", ' +
+                    '"p[5].b[2].bco=25388", ' +
+                    '"p[5].b[3].bco=25388", ' +
+                    '"p[6].b[1].bco=25388", ' +
+                    '"p[6].b[2].bco=25388", ' +
+                    '"p[6].b[3].bco=25388", ' +
+                    '"p[7].b[1].bco=25388", ' +
+                    '"p[7].b[2].bco=25388", ' +
+                    '"p[7].b[3].bco=25388", ' +
+                    '"p[8].b[1].bco=25388", ' +
+                    '"p[8].b[2].bco=25388", ' +
+                    '"p[8].b[3].bco=25388", ' +
+                    '"p[9].b[1].bco=25388", ' +
+                    '"p[9].b[2].bco=25388", ' +
+                    '"p[9].b[3].bco=25388", ' +
+                    '"p[1].b[1].txt=\\"' + plate02_pagebutton1txt + '\\"", ' +  //Initialize bottom page button text
+                    '"p[1].b[2].txt=\\"' + plate02_pagebutton2txt + '\\"", ' +
+                    '"p[1].b[3].txt=\\"' + plate02_pagebutton3txt + '\\"", ' +
+                    '"p[2].b[1].txt=\\"' + plate02_pagebutton1txt + '\\"", ' +
+                    '"p[2].b[2].txt=\\"' + plate02_pagebutton2txt + '\\"", ' +
+                    '"p[2].b[3].txt=\\"' + plate02_pagebutton3txt + '\\"", ' +
+                    '"p[3].b[1].txt=\\"' + plate02_pagebutton1txt + '\\"", ' +
+                    '"p[3].b[2].txt=\\"' + plate02_pagebutton2txt + '\\"", ' +
+                    '"p[3].b[3].txt=\\"' + plate02_pagebutton3txt + '\\"", ' +
+                    '"p[4].b[1].txt=\\"' + plate02_pagebutton1txt + '\\"", ' +
+                    '"p[4].b[2].txt=\\"' + plate02_pagebutton2txt + '\\"", ' +
+                    '"p[4].b[3].txt=\\"' + plate02_pagebutton3txt + '\\"", ' +
+                    '"p[5].b[1].txt=\\"' + plate02_pagebutton1txt + '\\"", ' +
+                    '"p[5].b[2].txt=\\"' + plate02_pagebutton2txt + '\\"", ' +
+                    '"p[5].b[3].txt=\\"' + plate02_pagebutton3txt + '\\"", ' +
+                    '"p[6].b[1].txt=\\"' + plate02_pagebutton1txt + '\\"", ' +
+                    '"p[6].b[2].txt=\\"' + plate02_pagebutton2txt + '\\"", ' +
+                    '"p[6].b[3].txt=\\"' + plate02_pagebutton3txt + '\\"", ' +
+                    '"p[7].b[1].txt=\\"' + plate02_pagebutton1txt + '\\"", ' +
+                    '"p[7].b[2].txt=\\"' + plate02_pagebutton2txt + '\\"", ' +
+                    '"p[7].b[3].txt=\\"' + plate02_pagebutton3txt + '\\"", ' +
+                    '"p[8].b[1].txt=\\"' + plate02_pagebutton1txt + '\\"", ' +
+                    '"p[8].b[2].txt=\\"' + plate02_pagebutton2txt + '\\"", ' +
+                    '"p[8].b[3].txt=\\"' + plate02_pagebutton3txt + '\\"", ' +
+                    '"p[9].b[1].txt=\\"' + plate02_pagebutton1txt + '\\"", ' +
+                    '"p[9].b[2].txt=\\"' + plate02_pagebutton2txt + '\\"", ' +
+                    '"p[9].b[3].txt=\\"' + plate02_pagebutton3txt + '\\""]'                  
 
-    /* Build Page 1 */
-    HASP_Plate02_Button_P1B4_Text.sendCommand(plate02_page1button4txt)
-    HASP_Plate02_Button_P1B5_Text.sendCommand(plate02_page1button5txt)
-    HASP_Plate02_Button_P1B6_Text.sendCommand(plate02_page1button6txt)
-    HASP_Plate02_Button_P1B7_Text.sendCommand(plate02_page1button7txt)
-    HASP_Plate02_Button_P1B4_Font.sendCommand(plate02_page1button4font)
-    HASP_Plate02_Button_P1B5_Font.sendCommand(plate02_page1button5font)
-    HASP_Plate02_Button_P1B6_Font.sendCommand(plate02_page1button6font)
-    HASP_Plate02_Button_P1B7_Font.sendCommand(plate02_page1button7font)
+    HASP_Plate02_Plate_Command_JSON.sendCommand(jsonString)
 
-    /* Build Page 2 */
-    HASP_Plate02_Button_P2B4_Text.sendCommand(plate02_page2button4txt)
-    HASP_Plate02_Button_P2B5_Text.sendCommand(plate02_page2button5txt)
-    HASP_Plate02_Button_P2B6_Text.sendCommand(plate02_page2button6txt)
-    HASP_Plate02_Button_P2B7_Text.sendCommand(plate02_page2button7txt)
-    HASP_Plate02_Button_P2B4_Font.sendCommand(plate02_page2button4font)
-    HASP_Plate02_Button_P2B5_Font.sendCommand(plate02_page2button5font)
-    HASP_Plate02_Button_P2B6_Font.sendCommand(plate02_page2button6font)
-    HASP_Plate02_Button_P2B7_Font.sendCommand(plate02_page2button7font)
+    jsonString = '["p[1].b[4].txt=\\"' + plate02_page1button4txt + '\\"", ' +    // Update button texts for all pages
+                     '"p[1].b[5].txt=\\"' + plate02_page1button5txt + '\\"", ' +
+                     '"p[1].b[6].txt=\\"' + plate02_page1button6txt + '\\"", ' +
+                     '"p[1].b[7].txt=\\"' + plate02_page1button7txt + '\\"", ' +
+                     '"p[2].b[4].txt=\\"' + plate02_page2button4txt + '\\"", ' +
+                     '"p[2].b[5].txt=\\"' + plate02_page2button5txt + '\\"", ' +
+                     '"p[2].b[6].txt=\\"' + plate02_page2button6txt + '\\"", ' +
+                     '"p[2].b[7].txt=\\"' + plate02_page2button7txt + '\\"", ' +
+                     '"p[3].b[4].txt=\\"' + plate02_page3button4txt + '\\"", ' +
+                     '"p[3].b[5].txt=\\"' + plate02_page3button5txt + '\\"", ' +
+                     '"p[3].b[6].txt=\\"' + plate02_page3button6txt + '\\"", ' +
+                     '"p[3].b[7].txt=\\"' + plate02_page3button7txt + '\\"", ' +                                                                                                                                                   
+                     '"p[4].b[4].txt=\\"' + plate02_page4button4txt + '\\"", ' +
+                     '"p[4].b[5].txt=\\"' + plate02_page4button5txt + '\\"", ' +
+                     '"p[4].b[6].txt=\\"' + plate02_page4button6txt + '\\"", ' +
+                     '"p[5].b[4].txt=\\"' + plate02_page5button4txt + '\\"", ' +
+                     '"p[5].b[5].txt=\\"' + plate02_page5button5txt + '\\"", ' +
+                     '"p[5].b[6].txt=\\"' + plate02_page5button6txt + '\\"", ' +   
+                     '"p[6].b[4].txt=\\"' + plate02_page6button4txt + '\\"", ' +
+                     '"p[6].b[5].txt=\\"' + plate02_page6button5txt + '\\"", ' +
+                     '"p[6].b[6].txt=\\"' + plate02_page6button6txt + '\\"", ' +
+                     '"p[6].b[7].txt=\\"' + plate02_page6button7txt + '\\"", ' +
+                     '"p[6].b[8].txt=\\"' + plate02_page6button8txt + '\\"", ' +
+                     '"p[6].b[9].txt=\\"' + plate02_page6button9txt + '\\"", ' +
+                     '"p[6].b[10].txt=\\"' + plate02_page6button10txt + '\\"", ' +
+                     '"p[6].b[11].txt=\\"' + plate02_page6button11txt + '\\"", ' +
+                     '"p[7].b[4].txt=\\"' + plate02_page7button4txt + '\\"", ' +
+                     '"p[7].b[5].txt=\\"' + plate02_page7button5txt + '\\"", ' +
+                     '"p[7].b[6].txt=\\"' + plate02_page7button6txt + '\\"", ' +
+                     '"p[7].b[7].txt=\\"' + plate02_page7button7txt + '\\"", ' +
+                     '"p[7].b[8].txt=\\"' + plate02_page7button8txt + '\\"", ' +
+                     '"p[7].b[9].txt=\\"' + plate02_page7button9txt + '\\"", ' +
+                     '"p[7].b[10].txt=\\"' + plate02_page7button10txt + '\\"", ' +
+                     '"p[7].b[11].txt=\\"' + plate02_page7button11txt + '\\"", ' +
+                     '"p[7].b[12].txt=\\"' + plate02_page7button12txt + '\\"", ' +
+                     '"p[7].b[13].txt=\\"' + plate02_page7button13txt + '\\"", ' +
+                     '"p[7].b[14].txt=\\"' + plate02_page7button14txt + '\\"", ' +
+                     '"p[7].b[15].txt=\\"' + plate02_page7button15txt + '\\"", ' +
+                     '"p[8].b[4].txt=\\"' + plate02_page8button4txt + '\\"", ' +
+                     '"p[8].b[5].txt=\\"' + plate02_page8button5txt + '\\"", ' +
+                     '"p[8].b[6].txt=\\"' + plate02_page8button6txt + '\\"", ' +
+                     '"p[8].b[7].txt=\\"' + plate02_page8button7txt + '\\"", ' +
+                     '"p[8].b[8].txt=\\"' + plate02_page8button8txt + '\\"", ' + 
+                     '"p[9].b[4].txt=\\"' + plate02_page9button4txt + '\\"", ' +
+                     '"p[9].b[5].txt=\\"' + plate02_page9button5txt + '\\""]'
 
-    /* Build Page 3 */
-    HASP_Plate02_Button_P3B4_Text.sendCommand(plate02_page3button4txt)
-    HASP_Plate02_Button_P3B5_Text.sendCommand(plate02_page3button5txt)
-    HASP_Plate02_Button_P3B6_Text.sendCommand(plate02_page3button6txt)
-    HASP_Plate02_Button_P3B7_Text.sendCommand(plate02_page3button7txt)
-    HASP_Plate02_Button_P3B4_Font.sendCommand(plate02_page3button4font)
-    HASP_Plate02_Button_P3B5_Font.sendCommand(plate02_page3button5font)
-    HASP_Plate02_Button_P3B6_Font.sendCommand(plate02_page3button6font)
-    HASP_Plate02_Button_P3B7_Font.sendCommand(plate02_page3button7font)
+    HASP_Plate02_Plate_Command_JSON.sendCommand(jsonString)
 
-    /* Build Page 4 */
-    HASP_Plate02_Button_P4B4_Text.sendCommand(plate02_page4button4txt)
-    HASP_Plate02_Button_P4B5_Text.sendCommand(plate02_page4button5txt)
-    HASP_Plate02_Button_P4B6_Text.sendCommand(plate02_page4button6txt)
-    HASP_Plate02_Button_P4B4_Font.sendCommand(plate02_page4button4font)
-    HASP_Plate02_Button_P4B5_Font.sendCommand(plate02_page4button5font)
-    HASP_Plate02_Button_P4B6_Font.sendCommand(plate02_page4button6font)
-    
-    /* Build Page 5 */
-    HASP_Plate02_Button_P5B4_Text.sendCommand(plate02_page5button4txt)
-    HASP_Plate02_Button_P5B5_Text.sendCommand(plate02_page5button5txt)
-    HASP_Plate02_Button_P5B6_Text.sendCommand(plate02_page5button6txt)
-    HASP_Plate02_Button_P5B4_Font.sendCommand(plate02_page5button4font)
-    HASP_Plate02_Button_P5B5_Font.sendCommand(plate02_page5button5font)
-    HASP_Plate02_Button_P5B6_Font.sendCommand(plate02_page5button6font)
+    jsonString = '["p[1].b[4].font=' + plate02_page1button4font + '", ' +    // Update font sizes for all pages
+                     '"p[1].b[5].font=' + plate02_page1button5font + '", ' +
+                     '"p[1].b[6].font=' + plate02_page1button6font + '", ' +
+                     '"p[1].b[7].font=' + plate02_page1button7font + '", ' +
+                     '"p[2].b[4].font=' + plate02_page2button4font + '", ' +
+                     '"p[2].b[5].font=' + plate02_page2button5font + '", ' +
+                     '"p[2].b[6].font=' + plate02_page2button6font + '", ' +
+                     '"p[2].b[7].font=' + plate02_page2button7font + '", ' +
+                     '"p[3].b[4].font=' + plate02_page3button4font + '", ' +
+                     '"p[3].b[5].font=' + plate02_page3button5font + '", ' +
+                     '"p[3].b[6].font=' + plate02_page3button6font + '", ' +
+                     '"p[3].b[7].font=' + plate02_page3button7font + '", ' +                                                                                                                                                   
+                     '"p[4].b[4].font=' + plate02_page4button4font + '", ' +
+                     '"p[4].b[5].font=' + plate02_page4button5font + '", ' +
+                     '"p[4].b[6].font=' + plate02_page4button6font + '", ' +
+                     '"p[5].b[4].font=' + plate02_page5button4font + '", ' +
+                     '"p[5].b[5].font=' + plate02_page5button5font + '", ' +
+                     '"p[5].b[6].font=' + plate02_page5button6font + '", ' +   
+                     '"p[6].b[4].font=' + plate02_page6button4font + '", ' +
+                     '"p[6].b[5].font=' + plate02_page6button5font + '", ' +
+                     '"p[6].b[6].font=' + plate02_page6button6font + '", ' +
+                     '"p[6].b[7].font=' + plate02_page6button7font + '", ' +
+                     '"p[6].b[8].font=' + plate02_page6button8font + '", ' +
+                     '"p[6].b[9].font=' + plate02_page6button9font + '", ' +
+                     '"p[6].b[10].font=' + plate02_page6button10font + '", ' +
+                     '"p[6].b[11].font=' + plate02_page6button11font + '", ' +
+                     '"p[7].b[4].font=' + plate02_page7button4font + '", ' +
+                     '"p[7].b[5].font=' + plate02_page7button5font + '", ' +
+                     '"p[7].b[6].font=' + plate02_page7button6font + '", ' +
+                     '"p[7].b[7].font=' + plate02_page7button7font + '", ' +
+                     '"p[7].b[8].font=' + plate02_page7button8font + '", ' +
+                     '"p[7].b[9].font=' + plate02_page7button9font + '", ' +
+                     '"p[7].b[10].font=' + plate02_page7button10font + '", ' +
+                     '"p[7].b[11].font=' + plate02_page7button11font + '", ' +
+                     '"p[7].b[12].font=' + plate02_page7button12font + '", ' +
+                     '"p[7].b[13].font=' + plate02_page7button13font + '", ' +
+                     '"p[7].b[14].font=' + plate02_page7button14font + '", ' +
+                     '"p[7].b[15].font=' + plate02_page7button15font + '", ' +
+                     '"p[8].b[4].font=' + plate02_page8button4font + '", ' +
+                     '"p[8].b[5].font=' + plate02_page8button5font + '", ' +
+                     '"p[8].b[6].font=' + plate02_page8button6font + '", ' +
+                     '"p[8].b[7].font=' + plate02_page8button7font + '", ' +
+                     '"p[8].b[8].font=' + plate02_page8button8font + '", ' + 
+                     '"p[9].b[4].font=' + plate02_page9button4font + '", ' +
+                     '"p[9].b[5].font=' + plate02_page9button5font + '"]'
 
-    /* Build Page 6 */
-    HASP_Plate02_Button_P6B4_Text.sendCommand(plate02_page6button4txt)
-    HASP_Plate02_Button_P6B5_Text.sendCommand(plate02_page6button5txt)
-    HASP_Plate02_Button_P6B6_Text.sendCommand(plate02_page6button6txt)
-    HASP_Plate02_Button_P6B7_Text.sendCommand(plate02_page6button7txt)
-    HASP_Plate02_Button_P6B8_Text.sendCommand(plate02_page6button8txt)
-    HASP_Plate02_Button_P6B9_Text.sendCommand(plate02_page6button9txt)
-    HASP_Plate02_Button_P6B10_Text.sendCommand(plate02_page6button10txt)
-    HASP_Plate02_Button_P6B11_Text.sendCommand(plate02_page6button11txt)
-    HASP_Plate02_Button_P6B4_Font.sendCommand(plate02_page6button4font)
-    HASP_Plate02_Button_P6B5_Font.sendCommand(plate02_page6button5font)
-    HASP_Plate02_Button_P6B6_Font.sendCommand(plate02_page6button6font)
-    HASP_Plate02_Button_P6B7_Font.sendCommand(plate02_page6button7font)
-    HASP_Plate02_Button_P6B8_Font.sendCommand(plate02_page6button8font)
-    HASP_Plate02_Button_P6B9_Font.sendCommand(plate02_page6button9font)
-    HASP_Plate02_Button_P6B10_Font.sendCommand(plate02_page6button10font)
-    HASP_Plate02_Button_P6B11_Font.sendCommand(plate02_page6button11font)
-    
-    /* Build Page 7 */
-    HASP_Plate02_Button_P7B4_Text.sendCommand(plate02_page7button4txt)
-    HASP_Plate02_Button_P7B5_Text.sendCommand(plate02_page7button5txt)
-    HASP_Plate02_Button_P7B6_Text.sendCommand(plate02_page7button6txt)
-    HASP_Plate02_Button_P7B7_Text.sendCommand(plate02_page7button7txt)
-    HASP_Plate02_Button_P7B8_Text.sendCommand(plate02_page7button8txt)
-    HASP_Plate02_Button_P7B9_Text.sendCommand(plate02_page7button9txt)
-    HASP_Plate02_Button_P7B10_Text.sendCommand(plate02_page7button10txt)
-    HASP_Plate02_Button_P7B11_Text.sendCommand(plate02_page7button11txt)
-    HASP_Plate02_Button_P7B12_Text.sendCommand(plate02_page7button12txt)
-    HASP_Plate02_Button_P7B13_Text.sendCommand(plate02_page7button13txt)
-    HASP_Plate02_Button_P7B14_Text.sendCommand(plate02_page7button14txt)
-    HASP_Plate02_Button_P7B15_Text.sendCommand(plate02_page7button15txt)
-    HASP_Plate02_Button_P7B4_Font.sendCommand(plate02_page7button4font)
-    HASP_Plate02_Button_P7B5_Font.sendCommand(plate02_page7button5font)
-    HASP_Plate02_Button_P7B6_Font.sendCommand(plate02_page7button6font)
-    HASP_Plate02_Button_P7B7_Font.sendCommand(plate02_page7button7font)
-    HASP_Plate02_Button_P7B8_Font.sendCommand(plate02_page7button8font)
-    HASP_Plate02_Button_P7B9_Font.sendCommand(plate02_page7button9font)
-    HASP_Plate02_Button_P7B10_Font.sendCommand(plate02_page7button10font)
-    HASP_Plate02_Button_P7B11_Font.sendCommand(plate02_page7button11font)
-    HASP_Plate02_Button_P7B12_Font.sendCommand(plate02_page7button12font)
-    HASP_Plate02_Button_P7B13_Font.sendCommand(plate02_page7button13font)
-    HASP_Plate02_Button_P7B14_Font.sendCommand(plate02_page7button14font)
-    HASP_Plate02_Button_P7B15_Font.sendCommand(plate02_page7button15font)
-    
-    /* Build Page 8 */
-    HASP_Plate02_Button_P8B4_Text.sendCommand(plate02_page8button4txt)
-    HASP_Plate02_Button_P8B5_Text.sendCommand(plate02_page8button5txt)
-    HASP_Plate02_Button_P8B6_Text.sendCommand(plate02_page8button6txt)
-    HASP_Plate02_Button_P8B7_Text.sendCommand(plate02_page8button7txt)
-    HASP_Plate02_Button_P8B8_Text.sendCommand(plate02_page8button8txt)
-    HASP_Plate02_Button_P8B4_Font.sendCommand(plate02_page8button4font)
-    HASP_Plate02_Button_P8B5_Font.sendCommand(plate02_page8button5font)
-    HASP_Plate02_Button_P8B6_Font.sendCommand(plate02_page8button6font)
-    HASP_Plate02_Button_P8B7_Font.sendCommand(plate02_page8button7font)
-    HASP_Plate02_Button_P8B8_Font.sendCommand(plate02_page8button8font)
-    
-    /* Build Page 9 */
-    HASP_Plate02_Button_P9B4_Text.sendCommand(plate02_page9button4txt)
-    HASP_Plate02_Button_P9B5_Text.sendCommand(plate02_page9button5txt)
-    HASP_Plate02_Button_P9B4_Font.sendCommand(plate02_page9button4font)
-    HASP_Plate02_Button_P9B5_Font.sendCommand(plate02_page9button5font)
-    
+    HASP_Plate02_Plate_Command_JSON.sendCommand(jsonString)
+   
 end
 
 /* Select hasp_plate02_page in response to page button 1 */
@@ -748,23 +787,27 @@ rule "HASP Foyer set page button colors on page change"
 when
     Item HASP_Plate02_Page_Current received update 
 then
-    if (HASP_Plate02_Page_Current <> 0)
+    if (HASP_Plate02_Page_Current.state != 0)
     {
         var jsonString = '["p['+ (HASP_Plate02_Page_Current.state.toString) + '].b[1].bco=25388", ' +
                             '"p['+ (HASP_Plate02_Page_Current.state.toString) + '].b[2].bco=25388", ' +
-                            '"p['+ (HASP_Plate02_Page_Current.state.toString) + '].b[3].bco=25388", '
+                            '"p['+ (HASP_Plate02_Page_Current.state.toString) + '].b[3].bco=25388"'
 
         if (HASP_Plate02_Page_Current.state == plate02_pagebutton1page)
         {
-                jsonString = jsonString + '"p['+ (HASP_Plate02_Page_Current.state.toString) + '].b[1].bco=65535"]'
+                jsonString = jsonString + ', "p['+ (HASP_Plate02_Page_Current.state.toString) + '].b[1].bco=65535"]'
         }
         else if (HASP_Plate02_Page_Current.state == plate02_pagebutton2page)
         {
-                jsonString = jsonString + '"p['+ (HASP_Plate02_Page_Current.state.toString) + '].b[2].bco=65535"]'
+                jsonString = jsonString + ', "p['+ (HASP_Plate02_Page_Current.state.toString) + '].b[2].bco=65535"]'
         }
         else if (HASP_Plate02_Page_Current.state == plate02_pagebutton3page)
         {
-                jsonString = jsonString + '"p['+ (HASP_Plate02_Page_Current.state.toString) + '].b[3].bco=65535"]'
+                jsonString = jsonString + ', "p['+ (HASP_Plate02_Page_Current.state.toString) + '].b[3].bco=65535"]'
+        }
+        else 
+        {
+                jsonString = jsonString + ']'
         }
 
         HASP_Plate02_Plate_Command_JSON.sendCommand(jsonString)

--- a/contrib/openHAB/HASP-Master.items
+++ b/contrib/openHAB/HASP-Master.items
@@ -1,12 +1,6 @@
 Group HASP_Plate01_Button1_Group
 Group HASP_Plate01_Button2_Group
 Group HASP_Plate01_Button3_Group
-Group HASP_Plate01_Button1_Text_Group
-Group HASP_Plate01_Button2_Text_Group
-Group HASP_Plate01_Button3_Text_Group
-Group HASP_Plate01_Button1_Bcol_Group
-Group HASP_Plate01_Button2_Bcol_Group
-Group HASP_Plate01_Button3_Bcol_Group
 Group HASP_Plate01_Page1_Button_Group
 Group HASP_Plate01_Page2_Button_Group
 Group HASP_Plate01_Page3_Button_Group
@@ -31,24 +25,6 @@ Switch HASP_Plate01_Button_P6B1 "HASP Plate 01 Page 6 Button 1 State [%s]" (HASP
 Switch HASP_Plate01_Button_P7B1 "HASP Plate 01 Page 7 Button 1 State [%s]" (HASP_Plate01_Button1_Group)  {mqtt="<[broker:hasp/plate01/state/p[7].b[1]:state:default]"}
 Switch HASP_Plate01_Button_P8B1 "HASP Plate 01 Page 8 Button 1 State [%s]" (HASP_Plate01_Button1_Group)  {mqtt="<[broker:hasp/plate01/state/p[8].b[1]:state:default]"}
 Switch HASP_Plate01_Button_P9B1 "HASP Plate 01 Page 9 Button 1 State [%s]" (HASP_Plate01_Button1_Group)  {mqtt="<[broker:hasp/plate01/state/p[9].b[1]:state:default]"}
-String HASP_Plate01_Button_P1B1_Text "HASP Plate 01 Page 1 Button 1 Text [%s]" (HASP_Plate01_Button1_Text_Group) {mqtt=">[broker:hasp/plate01/command/p[1].b[1].txt:command:*:default]"}
-String HASP_Plate01_Button_P2B1_Text "HASP Plate 01 Page 2 Button 1 Text [%s]" (HASP_Plate01_Button1_Text_Group) {mqtt=">[broker:hasp/plate01/command/p[2].b[1].txt:command:*:default]"}
-String HASP_Plate01_Button_P3B1_Text "HASP Plate 01 Page 3 Button 1 Text [%s]" (HASP_Plate01_Button1_Text_Group) {mqtt=">[broker:hasp/plate01/command/p[3].b[1].txt:command:*:default]"}
-String HASP_Plate01_Button_P4B1_Text "HASP Plate 01 Page 4 Button 1 Text [%s]" (HASP_Plate01_Button1_Text_Group) {mqtt=">[broker:hasp/plate01/command/p[4].b[1].txt:command:*:default]"}
-String HASP_Plate01_Button_P5B1_Text "HASP Plate 01 Page 5 Button 1 Text [%s]" (HASP_Plate01_Button1_Text_Group) {mqtt=">[broker:hasp/plate01/command/p[5].b[1].txt:command:*:default]"}
-String HASP_Plate01_Button_P6B1_Text "HASP Plate 01 Page 6 Button 1 Text [%s]" (HASP_Plate01_Button1_Text_Group) {mqtt=">[broker:hasp/plate01/command/p[6].b[1].txt:command:*:default]"}
-String HASP_Plate01_Button_P7B1_Text "HASP Plate 01 Page 7 Button 1 Text [%s]" (HASP_Plate01_Button1_Text_Group) {mqtt=">[broker:hasp/plate01/command/p[7].b[1].txt:command:*:default]"}
-String HASP_Plate01_Button_P8B1_Text "HASP Plate 01 Page 8 Button 1 Text [%s]" (HASP_Plate01_Button1_Text_Group) {mqtt=">[broker:hasp/plate01/command/p[8].b[1].txt:command:*:default]"}
-String HASP_Plate01_Button_P9B1_Text "HASP Plate 01 Page 9 Button 1 Text [%s]" (HASP_Plate01_Button1_Text_Group) {mqtt=">[broker:hasp/plate01/command/p[9].b[1].txt:command:*:default]"}
-Number HASP_Plate01_Button_P1B1_Bcol "HASP Plate 01 Page 1 Button 1 BCol [%d]" (HASP_Plate01_Button1_Bcol_Group) {mqtt=">[broker:hasp/plate01/command/p[1].b[1].bco:command:*:default]"}
-Number HASP_Plate01_Button_P2B1_Bcol "HASP Plate 01 Page 2 Button 1 BCol [%d]" (HASP_Plate01_Button1_Bcol_Group) {mqtt=">[broker:hasp/plate01/command/p[2].b[1].bco:command:*:default]"}
-Number HASP_Plate01_Button_P3B1_Bcol "HASP Plate 01 Page 3 Button 1 BCol [%d]" (HASP_Plate01_Button1_Bcol_Group) {mqtt=">[broker:hasp/plate01/command/p[3].b[1].bco:command:*:default]"}
-Number HASP_Plate01_Button_P4B1_Bcol "HASP Plate 01 Page 4 Button 1 BCol [%d]" (HASP_Plate01_Button1_Bcol_Group) {mqtt=">[broker:hasp/plate01/command/p[4].b[1].bco:command:*:default]"}
-Number HASP_Plate01_Button_P5B1_Bcol "HASP Plate 01 Page 5 Button 1 BCol [%d]" (HASP_Plate01_Button1_Bcol_Group) {mqtt=">[broker:hasp/plate01/command/p[5].b[1].bco:command:*:default]"}
-Number HASP_Plate01_Button_P6B1_Bcol "HASP Plate 01 Page 6 Button 1 BCol [%d]" (HASP_Plate01_Button1_Bcol_Group) {mqtt=">[broker:hasp/plate01/command/p[6].b[1].bco:command:*:default]"}
-Number HASP_Plate01_Button_P7B1_Bcol "HASP Plate 01 Page 7 Button 1 BCol [%d]" (HASP_Plate01_Button1_Bcol_Group) {mqtt=">[broker:hasp/plate01/command/p[7].b[1].bco:command:*:default]"}
-Number HASP_Plate01_Button_P8B1_Bcol "HASP Plate 01 Page 8 Button 1 BCol [%d]" (HASP_Plate01_Button1_Bcol_Group) {mqtt=">[broker:hasp/plate01/command/p[8].b[1].bco:command:*:default]"}
-Number HASP_Plate01_Button_P9B1_Bcol "HASP Plate 01 Page 9 Button 1 BCol [%d]" (HASP_Plate01_Button1_Bcol_Group) {mqtt=">[broker:hasp/plate01/command/p[9].b[1].bco:command:*:default]"}
 
 Switch HASP_Plate01_Button_P1B2 "HASP Plate 01 Page 1 Button 2 State [%s]" (HASP_Plate01_Button2_Group)  {mqtt="<[broker:hasp/plate01/state/p[1].b[2]:state:default]"}
 Switch HASP_Plate01_Button_P2B2 "HASP Plate 01 Page 2 Button 2 State [%s]" (HASP_Plate01_Button2_Group)  {mqtt="<[broker:hasp/plate01/state/p[2].b[2]:state:default]"}
@@ -59,24 +35,6 @@ Switch HASP_Plate01_Button_P6B2 "HASP Plate 01 Page 6 Button 2 State [%s]" (HASP
 Switch HASP_Plate01_Button_P7B2 "HASP Plate 01 Page 7 Button 2 State [%s]" (HASP_Plate01_Button2_Group)  {mqtt="<[broker:hasp/plate01/state/p[7].b[2]:state:default]"}
 Switch HASP_Plate01_Button_P8B2 "HASP Plate 01 Page 8 Button 2 State [%s]" (HASP_Plate01_Button2_Group)  {mqtt="<[broker:hasp/plate01/state/p[8].b[2]:state:default]"}
 Switch HASP_Plate01_Button_P9B2 "HASP Plate 01 Page 9 Button 2 State [%s]" (HASP_Plate01_Button2_Group)  {mqtt="<[broker:hasp/plate01/state/p[9].b[2]:state:default]"}
-String HASP_Plate01_Button_P1B2_Text "HASP Plate 01 Page 1 Button 2 Text [%s]" (HASP_Plate01_Button2_Text_Group) {mqtt=">[broker:hasp/plate01/command/p[1].b[2].txt:command:*:default]"}
-String HASP_Plate01_Button_P2B2_Text "HASP Plate 01 Page 2 Button 2 Text [%s]" (HASP_Plate01_Button2_Text_Group) {mqtt=">[broker:hasp/plate01/command/p[2].b[2].txt:command:*:default]"}
-String HASP_Plate01_Button_P3B2_Text "HASP Plate 01 Page 3 Button 2 Text [%s]" (HASP_Plate01_Button2_Text_Group) {mqtt=">[broker:hasp/plate01/command/p[3].b[2].txt:command:*:default]"}
-String HASP_Plate01_Button_P4B2_Text "HASP Plate 01 Page 4 Button 2 Text [%s]" (HASP_Plate01_Button2_Text_Group) {mqtt=">[broker:hasp/plate01/command/p[4].b[2].txt:command:*:default]"}
-String HASP_Plate01_Button_P5B2_Text "HASP Plate 01 Page 5 Button 2 Text [%s]" (HASP_Plate01_Button2_Text_Group) {mqtt=">[broker:hasp/plate01/command/p[5].b[2].txt:command:*:default]"}
-String HASP_Plate01_Button_P6B2_Text "HASP Plate 01 Page 6 Button 2 Text [%s]" (HASP_Plate01_Button2_Text_Group) {mqtt=">[broker:hasp/plate01/command/p[6].b[2].txt:command:*:default]"}
-String HASP_Plate01_Button_P7B2_Text "HASP Plate 01 Page 7 Button 2 Text [%s]" (HASP_Plate01_Button2_Text_Group) {mqtt=">[broker:hasp/plate01/command/p[7].b[2].txt:command:*:default]"}
-String HASP_Plate01_Button_P8B2_Text "HASP Plate 01 Page 8 Button 2 Text [%s]" (HASP_Plate01_Button2_Text_Group) {mqtt=">[broker:hasp/plate01/command/p[8].b[2].txt:command:*:default]"}
-String HASP_Plate01_Button_P9B2_Text "HASP Plate 01 Page 9 Button 2 Text [%s]" (HASP_Plate01_Button2_Text_Group) {mqtt=">[broker:hasp/plate01/command/p[9].b[2].txt:command:*:default]"}
-Number HASP_Plate01_Button_P1B2_Bcol "HASP Plate 01 Page 1 Button 2 BCol [%d]" (HASP_Plate01_Button2_Bcol_Group) {mqtt=">[broker:hasp/plate01/command/p[1].b[2].bco:command:*:default]"}
-Number HASP_Plate01_Button_P2B2_Bcol "HASP Plate 01 Page 2 Button 2 BCol [%d]" (HASP_Plate01_Button2_Bcol_Group) {mqtt=">[broker:hasp/plate01/command/p[2].b[2].bco:command:*:default]"}
-Number HASP_Plate01_Button_P3B2_Bcol "HASP Plate 01 Page 3 Button 2 BCol [%d]" (HASP_Plate01_Button2_Bcol_Group) {mqtt=">[broker:hasp/plate01/command/p[3].b[2].bco:command:*:default]"}
-Number HASP_Plate01_Button_P4B2_Bcol "HASP Plate 01 Page 4 Button 2 BCol [%d]" (HASP_Plate01_Button2_Bcol_Group) {mqtt=">[broker:hasp/plate01/command/p[4].b[2].bco:command:*:default]"}
-Number HASP_Plate01_Button_P5B2_Bcol "HASP Plate 01 Page 5 Button 2 BCol [%d]" (HASP_Plate01_Button2_Bcol_Group) {mqtt=">[broker:hasp/plate01/command/p[5].b[2].bco:command:*:default]"}
-Number HASP_Plate01_Button_P6B2_Bcol "HASP Plate 01 Page 6 Button 2 BCol [%d]" (HASP_Plate01_Button2_Bcol_Group) {mqtt=">[broker:hasp/plate01/command/p[6].b[2].bco:command:*:default]"}
-Number HASP_Plate01_Button_P7B2_Bcol "HASP Plate 01 Page 7 Button 2 BCol [%d]" (HASP_Plate01_Button2_Bcol_Group) {mqtt=">[broker:hasp/plate01/command/p[7].b[2].bco:command:*:default]"}
-Number HASP_Plate01_Button_P8B2_Bcol "HASP Plate 01 Page 8 Button 2 BCol [%d]" (HASP_Plate01_Button2_Bcol_Group) {mqtt=">[broker:hasp/plate01/command/p[8].b[2].bco:command:*:default]"}
-Number HASP_Plate01_Button_P9B2_Bcol "HASP Plate 01 Page 9 Button 2 BCol [%d]" (HASP_Plate01_Button2_Bcol_Group) {mqtt=">[broker:hasp/plate01/command/p[9].b[2].bco:command:*:default]"}
 
 Switch HASP_Plate01_Button_P1B3 "HASP Plate 01 Page 1 Button 3 State [%s]" (HASP_Plate01_Button3_Group)  {mqtt="<[broker:hasp/plate01/state/p[1].b[3]:state:default]"}
 Switch HASP_Plate01_Button_P2B3 "HASP Plate 01 Page 2 Button 3 State [%s]" (HASP_Plate01_Button3_Group)  {mqtt="<[broker:hasp/plate01/state/p[2].b[3]:state:default]"}
@@ -87,92 +45,29 @@ Switch HASP_Plate01_Button_P6B3 "HASP Plate 01 Page 6 Button 3 State [%s]" (HASP
 Switch HASP_Plate01_Button_P7B3 "HASP Plate 01 Page 7 Button 3 State [%s]" (HASP_Plate01_Button3_Group)  {mqtt="<[broker:hasp/plate01/state/p[7].b[3]:state:default]"}
 Switch HASP_Plate01_Button_P8B3 "HASP Plate 01 Page 8 Button 3 State [%s]" (HASP_Plate01_Button3_Group)  {mqtt="<[broker:hasp/plate01/state/p[8].b[3]:state:default]"}
 Switch HASP_Plate01_Button_P9B3 "HASP Plate 01 Page 9 Button 3 State [%s]" (HASP_Plate01_Button3_Group)  {mqtt="<[broker:hasp/plate01/state/p[9].b[3]:state:default]"}
-String HASP_Plate01_Button_P1B3_Text "HASP Plate 01 Page 1 Button 3 Text [%s]" (HASP_Plate01_Button3_Text_Group) {mqtt=">[broker:hasp/plate01/command/p[1].b[3].txt:command:*:default]"}
-String HASP_Plate01_Button_P2B3_Text "HASP Plate 01 Page 2 Button 3 Text [%s]" (HASP_Plate01_Button3_Text_Group) {mqtt=">[broker:hasp/plate01/command/p[2].b[3].txt:command:*:default]"}
-String HASP_Plate01_Button_P3B3_Text "HASP Plate 01 Page 3 Button 3 Text [%s]" (HASP_Plate01_Button3_Text_Group) {mqtt=">[broker:hasp/plate01/command/p[3].b[3].txt:command:*:default]"}
-String HASP_Plate01_Button_P4B3_Text "HASP Plate 01 Page 4 Button 3 Text [%s]" (HASP_Plate01_Button3_Text_Group) {mqtt=">[broker:hasp/plate01/command/p[4].b[3].txt:command:*:default]"}
-String HASP_Plate01_Button_P5B3_Text "HASP Plate 01 Page 5 Button 3 Text [%s]" (HASP_Plate01_Button3_Text_Group) {mqtt=">[broker:hasp/plate01/command/p[5].b[3].txt:command:*:default]"}
-String HASP_Plate01_Button_P6B3_Text "HASP Plate 01 Page 6 Button 3 Text [%s]" (HASP_Plate01_Button3_Text_Group) {mqtt=">[broker:hasp/plate01/command/p[6].b[3].txt:command:*:default]"}
-String HASP_Plate01_Button_P7B3_Text "HASP Plate 01 Page 7 Button 3 Text [%s]" (HASP_Plate01_Button3_Text_Group) {mqtt=">[broker:hasp/plate01/command/p[7].b[3].txt:command:*:default]"}
-String HASP_Plate01_Button_P8B3_Text "HASP Plate 01 Page 8 Button 3 Text [%s]" (HASP_Plate01_Button3_Text_Group) {mqtt=">[broker:hasp/plate01/command/p[8].b[3].txt:command:*:default]"}
-String HASP_Plate01_Button_P9B3_Text "HASP Plate 01 Page 9 Button 3 Text [%s]" (HASP_Plate01_Button3_Text_Group) {mqtt=">[broker:hasp/plate01/command/p[9].b[3].txt:command:*:default]"}
-Number HASP_Plate01_Button_P1B3_Bcol "HASP Plate 01 Page 1 Button 3 BCol [%d]" (HASP_Plate01_Button3_Bcol_Group) {mqtt=">[broker:hasp/plate01/command/p[1].b[3].bco:command:*:default]"}
-Number HASP_Plate01_Button_P2B3_Bcol "HASP Plate 01 Page 2 Button 3 BCol [%d]" (HASP_Plate01_Button3_Bcol_Group) {mqtt=">[broker:hasp/plate01/command/p[2].b[3].bco:command:*:default]"}
-Number HASP_Plate01_Button_P3B3_Bcol "HASP Plate 01 Page 3 Button 3 BCol [%d]" (HASP_Plate01_Button3_Bcol_Group) {mqtt=">[broker:hasp/plate01/command/p[3].b[3].bco:command:*:default]"}
-Number HASP_Plate01_Button_P4B3_Bcol "HASP Plate 01 Page 4 Button 3 BCol [%d]" (HASP_Plate01_Button3_Bcol_Group) {mqtt=">[broker:hasp/plate01/command/p[4].b[3].bco:command:*:default]"}
-Number HASP_Plate01_Button_P5B3_Bcol "HASP Plate 01 Page 5 Button 3 BCol [%d]" (HASP_Plate01_Button3_Bcol_Group) {mqtt=">[broker:hasp/plate01/command/p[5].b[3].bco:command:*:default]"}
-Number HASP_Plate01_Button_P6B3_Bcol "HASP Plate 01 Page 6 Button 3 BCol [%d]" (HASP_Plate01_Button3_Bcol_Group) {mqtt=">[broker:hasp/plate01/command/p[6].b[3].bco:command:*:default]"}
-Number HASP_Plate01_Button_P7B3_Bcol "HASP Plate 01 Page 7 Button 3 BCol [%d]" (HASP_Plate01_Button3_Bcol_Group) {mqtt=">[broker:hasp/plate01/command/p[7].b[3].bco:command:*:default]"}
-Number HASP_Plate01_Button_P8B3_Bcol "HASP Plate 01 Page 8 Button 3 BCol [%d]" (HASP_Plate01_Button3_Bcol_Group) {mqtt=">[broker:hasp/plate01/command/p[8].b[3].bco:command:*:default]"}
-Number HASP_Plate01_Button_P9B3_Bcol "HASP Plate 01 Page 9 Button 3 BCol [%d]" (HASP_Plate01_Button3_Bcol_Group) {mqtt=">[broker:hasp/plate01/command/p[9].b[3].bco:command:*:default]"}
 
 /* Page 1 Functional Items */
 Switch HASP_Plate01_Button_P1B4 "HASP Plate 01 Page 1 Button 4 State [%s]" (HASP_Plate01_Page1_Button_Group) {mqtt="<[broker:hasp/plate01/state/p[1].b[4]:state:default]"}
 Switch HASP_Plate01_Button_P1B5 "HASP Plate 01 Page 1 Button 5 State [%s]" (HASP_Plate01_Page1_Button_Group) {mqtt="<[broker:hasp/plate01/state/p[1].b[5]:state:default]"}
 Switch HASP_Plate01_Button_P1B6 "HASP Plate 01 Page 1 Button 6 State [%s]" (HASP_Plate01_Page1_Button_Group) {mqtt="<[broker:hasp/plate01/state/p[1].b[6]:state:default]"}
 Switch HASP_Plate01_Button_P1B7 "HASP Plate 01 Page 1 Button 7 State [%s]" (HASP_Plate01_Page1_Button_Group) {mqtt="<[broker:hasp/plate01/state/p[1].b[7]:state:default]"}
-String HASP_Plate01_Button_P1B4_Text "HASP Plate 01 Page 1 Button 4 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[1].b[4].txt:command:*:default]"}
-String HASP_Plate01_Button_P1B5_Text "HASP Plate 01 Page 1 Button 5 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[1].b[5].txt:command:*:default]"}
-String HASP_Plate01_Button_P1B6_Text "HASP Plate 01 Page 1 Button 6 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[1].b[6].txt:command:*:default]"}
-String HASP_Plate01_Button_P1B7_Text "HASP Plate 01 Page 1 Button 7 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[1].b[7].txt:command:*:default]"}
-Number HASP_Plate01_Button_P1B4_Bcol "HASP Plate 01 Page 1 Button 4 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[1].b[4].bco:command:*:default]"}
-Number HASP_Plate01_Button_P1B5_Bcol "HASP Plate 01 Page 1 Button 5 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[1].b[5].bco:command:*:default]"}
-Number HASP_Plate01_Button_P1B6_Bcol "HASP Plate 01 Page 1 Button 6 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[1].b[6].bco:command:*:default]"}
-Number HASP_Plate01_Button_P1B7_Bcol "HASP Plate 01 Page 1 Button 7 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[1].b[7].bco:command:*:default]"}
-Number HASP_Plate01_Button_P1B4_Font "HASP Plate 01 Page 1 Button 4 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[1].b[4].font:command:*:default]"}
-Number HASP_Plate01_Button_P1B5_Font "HASP Plate 01 Page 1 Button 5 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[1].b[5].font:command:*:default]"}
-Number HASP_Plate01_Button_P1B6_Font "HASP Plate 01 Page 1 Button 6 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[1].b[6].font:command:*:default]"}
-Number HASP_Plate01_Button_P1B7_Font "HASP Plate 01 Page 1 Button 7 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[1].b[7].font:command:*:default]"}
 
 /* Page 2 Functional Items */
 Switch HASP_Plate01_Button_P2B4 "HASP Plate 01 Page 2 Button 4 State [%s]" (HASP_Plate01_Page2_Button_Group) {mqtt="<[broker:hasp/plate01/state/p[2].b[4]:state:default]"}
 Switch HASP_Plate01_Button_P2B5 "HASP Plate 01 Page 2 Button 5 State [%s]" (HASP_Plate01_Page2_Button_Group) {mqtt="<[broker:hasp/plate01/state/p[2].b[5]:state:default]"}
 Switch HASP_Plate01_Button_P2B6 "HASP Plate 01 Page 2 Button 6 State [%s]" (HASP_Plate01_Page2_Button_Group) {mqtt="<[broker:hasp/plate01/state/p[2].b[6]:state:default]"}
 Switch HASP_Plate01_Button_P2B7 "HASP Plate 01 Page 2 Button 7 State [%s]" (HASP_Plate01_Page2_Button_Group) {mqtt="<[broker:hasp/plate01/state/p[2].b[7]:state:default]"}
-String HASP_Plate01_Button_P2B4_Text "HASP Plate 01 Page 2 Button 4 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[2].b[4].txt:command:*:default]"}
-String HASP_Plate01_Button_P2B5_Text "HASP Plate 01 Page 2 Button 5 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[2].b[5].txt:command:*:default]"}
-String HASP_Plate01_Button_P2B6_Text "HASP Plate 01 Page 2 Button 6 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[2].b[6].txt:command:*:default]"}
-String HASP_Plate01_Button_P2B7_Text "HASP Plate 01 Page 2 Button 7 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[2].b[7].txt:command:*:default]"}
-Number HASP_Plate01_Button_P2B4_Bcol "HASP Plate 01 Page 2 Button 4 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[2].b[4].bco:command:*:default]"}
-Number HASP_Plate01_Button_P2B5_Bcol "HASP Plate 01 Page 2 Button 5 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[2].b[5].bco:command:*:default]"}
-Number HASP_Plate01_Button_P2B6_Bcol "HASP Plate 01 Page 2 Button 6 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[2].b[6].bco:command:*:default]"}
-Number HASP_Plate01_Button_P2B7_Bcol "HASP Plate 01 Page 2 Button 7 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[2].b[7].bco:command:*:default]"}
-Number HASP_Plate01_Button_P2B4_Font "HASP Plate 01 Page 2 Button 4 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[2].b[4].font:command:*:default]"}
-Number HASP_Plate01_Button_P2B5_Font "HASP Plate 01 Page 2 Button 5 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[2].b[5].font:command:*:default]"}
-Number HASP_Plate01_Button_P2B6_Font "HASP Plate 01 Page 2 Button 6 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[2].b[6].font:command:*:default]"}
-Number HASP_Plate01_Button_P2B7_Font "HASP Plate 01 Page 2 Button 7 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[2].b[7].font:command:*:default]"}
 
 /* Page 3 Functional Items */
 Switch HASP_Plate01_Button_P3B4 "HASP Plate 01 Page 3 Button 4 State [%s]" (HASP_Plate01_Page3_Button_Group) {mqtt="<[broker:hasp/plate01/state/p[3].b[4]:state:default]"}
 Switch HASP_Plate01_Button_P3B5 "HASP Plate 01 Page 3 Button 5 State [%s]" (HASP_Plate01_Page3_Button_Group) {mqtt="<[broker:hasp/plate01/state/p[3].b[5]:state:default]"}
 Switch HASP_Plate01_Button_P3B6 "HASP Plate 01 Page 3 Button 6 State [%s]" (HASP_Plate01_Page3_Button_Group) {mqtt="<[broker:hasp/plate01/state/p[3].b[6]:state:default]"}
 Switch HASP_Plate01_Button_P3B7 "HASP Plate 01 Page 3 Button 7 State [%s]" (HASP_Plate01_Page3_Button_Group) {mqtt="<[broker:hasp/plate01/state/p[3].b[7]:state:default]"}
-String HASP_Plate01_Button_P3B4_Text "HASP Plate 01 Page 3 Button 4 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[3].b[4].txt:command:*:default]"}
-String HASP_Plate01_Button_P3B5_Text "HASP Plate 01 Page 3 Button 5 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[3].b[5].txt:command:*:default]"}
-String HASP_Plate01_Button_P3B6_Text "HASP Plate 01 Page 3 Button 6 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[3].b[6].txt:command:*:default]"}
-String HASP_Plate01_Button_P3B7_Text "HASP Plate 01 Page 3 Button 7 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[3].b[7].txt:command:*:default]"}
-Number HASP_Plate01_Button_P3B4_Bcol "HASP Plate 01 Page 3 Button 4 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[3].b[4].bco:command:*:default]"}
-Number HASP_Plate01_Button_P3B5_Bcol "HASP Plate 01 Page 3 Button 5 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[3].b[5].bco:command:*:default]"}
-Number HASP_Plate01_Button_P3B6_Bcol "HASP Plate 01 Page 3 Button 6 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[3].b[6].bco:command:*:default]"}
-Number HASP_Plate01_Button_P3B7_Bcol "HASP Plate 01 Page 3 Button 7 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[3].b[7].bco:command:*:default]"}
-Number HASP_Plate01_Button_P3B4_Font "HASP Plate 01 Page 3 Button 4 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[3].b[4].font:command:*:default]"}
-Number HASP_Plate01_Button_P3B5_Font "HASP Plate 01 Page 3 Button 5 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[3].b[5].font:command:*:default]"}
-Number HASP_Plate01_Button_P3B6_Font "HASP Plate 01 Page 3 Button 6 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[3].b[6].font:command:*:default]"}
-Number HASP_Plate01_Button_P3B7_Font "HASP Plate 01 Page 3 Button 7 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[3].b[7].font:command:*:default]"}
 
 /* Page 4 Functional Items */
 Switch HASP_Plate01_Button_P4B4 "HASP Plate 01 Page 4 Button 4 State [%s]" (HASP_Plate01_Page4_Button_Group) {mqtt="<[broker:hasp/plate01/state/p[4].b[4]:state:default]"}
 Switch HASP_Plate01_Button_P4B5 "HASP Plate 01 Page 4 Button 5 State [%s]" (HASP_Plate01_Page4_Button_Group) {mqtt="<[broker:hasp/plate01/state/p[4].b[5]:state:default]"}
 Switch HASP_Plate01_Button_P4B6 "HASP Plate 01 Page 4 Button 6 State [%s]" (HASP_Plate01_Page4_Button_Group) {mqtt="<[broker:hasp/plate01/state/p[4].b[6]:state:default]"}
-String HASP_Plate01_Button_P4B4_Text "HASP Plate 01 Page 4 Button 4 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[4].b[4].txt:command:*:default]"}
-String HASP_Plate01_Button_P4B5_Text "HASP Plate 01 Page 4 Button 5 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[4].b[5].txt:command:*:default]"}
-String HASP_Plate01_Button_P4B6_Text "HASP Plate 01 Page 4 Button 6 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[4].b[6].txt:command:*:default]"}
-Number HASP_Plate01_Button_P4B4_Bcol "HASP Plate 01 Page 4 Button 4 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[4].b[4].bco:command:*:default]"}
-Number HASP_Plate01_Button_P4B5_Bcol "HASP Plate 01 Page 4 Button 5 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[4].b[5].bco:command:*:default]"}
-Number HASP_Plate01_Button_P4B6_Bcol "HASP Plate 01 Page 4 Button 6 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[4].b[6].bco:command:*:default]"}
-Number HASP_Plate01_Button_P4B4_Font "HASP Plate 01 Page 4 Button 4 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[4].b[4].font:command:*:default]"}
-Number HASP_Plate01_Button_P4B5_Font "HASP Plate 01 Page 4 Button 5 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[4].b[5].font:command:*:default]"}
-Number HASP_Plate01_Button_P4B6_Font "HASP Plate 01 Page 4 Button 6 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[4].b[6].font:command:*:default]"}
 Number HASP_Plate01_Dimmer_P4B7 "HASP Plate 01 Page 4 Dimmer 7 State [%d]" (HASP_Plate01_Page4_Dimmer_Group) {mqtt="<[broker:hasp/plate01/state/p[4].b[7].val:state:default]"}
 Number HASP_Plate01_Dimmer_P4B7_Val "HASP Plate 01 Page 4 Dimmer 7 Value" {mqtt=">[broker:hasp/plate01/command/p[4].b[7].val:command:*:default]"}
 Number HASP_Plate01_Dimmer_P4B8 "HASP Plate 01 Page 4 Dimmer 8 State [%d]" (HASP_Plate01_Page4_Dimmer_Group) {mqtt="<[broker:hasp/plate01/state/p[4].b[8].val:state:default]"}//",>[broker:hasp/plate01/command/p[4].b[8].val:command:*:default]"}
@@ -184,15 +79,6 @@ Number HASP_Plate01_Dimmer_P4B9_Val "HASP Plate 01 Page 4 Dimmer 9 Value" {mqtt=
 Switch HASP_Plate01_Button_P5B4 "HASP Plate 01 Page 5 Button 4 State [%s]" (HASP_Plate01_Page5_Button_Group) {mqtt="<[broker:hasp/plate01/state/p[5].b[4]:state:default]"}
 Switch HASP_Plate01_Button_P5B5 "HASP Plate 01 Page 5 Button 5 State [%s]" (HASP_Plate01_Page5_Button_Group) {mqtt="<[broker:hasp/plate01/state/p[5].b[5]:state:default]"}
 Switch HASP_Plate01_Button_P5B6 "HASP Plate 01 Page 5 Button 6 State [%s]" (HASP_Plate01_Page5_Button_Group) {mqtt="<[broker:hasp/plate01/state/p[5].b[6]:state:default]"}
-String HASP_Plate01_Button_P5B4_Text "HASP Plate 01 Page 5 Button 4 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[5].b[4].txt:command:*:default]"}
-String HASP_Plate01_Button_P5B5_Text "HASP Plate 01 Page 5 Button 5 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[5].b[5].txt:command:*:default]"}
-String HASP_Plate01_Button_P5B6_Text "HASP Plate 01 Page 5 Button 6 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[5].b[6].txt:command:*:default]"}
-Number HASP_Plate01_Button_P5B4_Bcol "HASP Plate 01 Page 5 Button 4 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[5].b[4].bco:command:*:default]"}
-Number HASP_Plate01_Button_P5B5_Bcol "HASP Plate 01 Page 5 Button 5 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[5].b[5].bco:command:*:default]"}
-Number HASP_Plate01_Button_P5B6_Bcol "HASP Plate 01 Page 5 Button 6 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[5].b[6].bco:command:*:default]"}
-Number HASP_Plate01_Button_P5B4_Font "HASP Plate 01 Page 5 Button 4 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[5].b[4].font:command:*:default]"}
-Number HASP_Plate01_Button_P5B5_Font "HASP Plate 01 Page 5 Button 5 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[5].b[5].font:command:*:default]"}
-Number HASP_Plate01_Button_P5B6_Font "HASP Plate 01 Page 5 Button 6 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[5].b[6].font:command:*:default]"}
 Number HASP_Plate01_Dimmer_P5B7 "HASP Plate 01 Page 5 Dimmer 7 State [%d]" (HASP_Plate01_Page5_Dimmer_Group) {mqtt="<[broker:hasp/plate01/state/p[5].b[7].val:state:default]"}//",>[broker:hasp/plate01/command/p[5].b[7].val:command:*:default]"}
 Number HASP_Plate01_Dimmer_P5B7_Val "HASP Plate 01 Page 5 Dimmer 7 Value" {mqtt=">[broker:hasp/plate01/command/p[5].b[7].val:command:*:default]"}
 Number HASP_Plate01_Dimmer_P5B8 "HASP Plate 01 Page 5 Dimmer 8 State [%d]" (HASP_Plate01_Page5_Dimmer_Group) {mqtt="<[broker:hasp/plate01/state/p[5].b[8].val:state:default]"}//",>[broker:hasp/plate01/command/p[5].b[8].val:command:*:default]"}
@@ -209,30 +95,6 @@ Switch HASP_Plate01_Button_P6B8 "HASP Plate 01 Page 6 Button 8 State [%s]" (HASP
 Switch HASP_Plate01_Button_P6B9 "HASP Plate 01 Page 6 Button 9 State [%s]" (HASP_Plate01_Page6_Button_Group) {mqtt="<[broker:hasp/plate01/state/p[6].b[9]:state:default]"}
 Switch HASP_Plate01_Button_P6B10 "HASP Plate 01 Page 6 Button 10 State [%s]" (HASP_Plate01_Page6_Button_Group) {mqtt="<[broker:hasp/plate01/state/p[6].b[10]:state:default]"}
 Switch HASP_Plate01_Button_P6B11 "HASP Plate 01 Page 6 Button 11 State [%s]" (HASP_Plate01_Page6_Button_Group) {mqtt="<[broker:hasp/plate01/state/p[6].b[11]:state:default]"}
-String HASP_Plate01_Button_P6B4_Text "HASP Plate 01 Page 6 Button 4 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[6].b[4].txt:command:*:default]"}
-String HASP_Plate01_Button_P6B5_Text "HASP Plate 01 Page 6 Button 5 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[6].b[5].txt:command:*:default]"}
-String HASP_Plate01_Button_P6B6_Text "HASP Plate 01 Page 6 Button 6 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[6].b[6].txt:command:*:default]"}
-String HASP_Plate01_Button_P6B7_Text "HASP Plate 01 Page 6 Button 7 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[6].b[7].txt:command:*:default]"}
-String HASP_Plate01_Button_P6B8_Text "HASP Plate 01 Page 6 Button 8 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[6].b[8].txt:command:*:default]"}
-String HASP_Plate01_Button_P6B9_Text "HASP Plate 01 Page 6 Button 9 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[6].b[9].txt:command:*:default]"}
-String HASP_Plate01_Button_P6B10_Text "HASP Plate 01 Page 6 Button 10 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[6].b[10].txt:command:*:default]"}
-String HASP_Plate01_Button_P6B11_Text "HASP Plate 01 Page 6 Button 11 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[6].b[11].txt:command:*:default]"}
-Number HASP_Plate01_Button_P6B4_Bcol "HASP Plate 01 Page 6 Button 4 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[6].b[4].bco:command:*:default]"}
-Number HASP_Plate01_Button_P6B5_Bcol "HASP Plate 01 Page 6 Button 5 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[6].b[5].bco:command:*:default]"}
-Number HASP_Plate01_Button_P6B6_Bcol "HASP Plate 01 Page 6 Button 6 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[6].b[6].bco:command:*:default]"}
-Number HASP_Plate01_Button_P6B7_Bcol "HASP Plate 01 Page 6 Button 7 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[6].b[7].bco:command:*:default]"}
-Number HASP_Plate01_Button_P6B8_Bcol "HASP Plate 01 Page 6 Button 8 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[6].b[8].bco:command:*:default]"}
-Number HASP_Plate01_Button_P6B9_Bcol "HASP Plate 01 Page 6 Button 9 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[6].b[9].bco:command:*:default]"}
-Number HASP_Plate01_Button_P6B10_Bcol "HASP Plate 01 Page 6 Button 10 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[6].b[10].bco:command:*:default]"}
-Number HASP_Plate01_Button_P6B11_Bcol "HASP Plate 01 Page 6 Button 11 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[6].b[11].bco:command:*:default]"}
-Number HASP_Plate01_Button_P6B4_Font "HASP Plate 01 Page 6 Button 4 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[6].b[4].font:command:*:default]"}
-Number HASP_Plate01_Button_P6B5_Font "HASP Plate 01 Page 6 Button 5 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[6].b[5].font:command:*:default]"}
-Number HASP_Plate01_Button_P6B6_Font "HASP Plate 01 Page 6 Button 6 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[6].b[6].font:command:*:default]"}
-Number HASP_Plate01_Button_P6B7_Font "HASP Plate 01 Page 6 Button 7 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[6].b[7].font:command:*:default]"}
-Number HASP_Plate01_Button_P6B8_Font "HASP Plate 01 Page 6 Button 8 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[6].b[8].font:command:*:default]"}
-Number HASP_Plate01_Button_P6B9_Font "HASP Plate 01 Page 6 Button 9 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[6].b[9].font:command:*:default]"}
-Number HASP_Plate01_Button_P6B10_Font "HASP Plate 01 Page 6 Button 10 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[6].b[10].font:command:*:default]"}
-Number HASP_Plate01_Button_P6B11_Font "HASP Plate 01 Page 6 Button 11 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[6].b[11].font:command:*:default]"}
 
 /* Page 7 Functional Items */
 Switch HASP_Plate01_Button_P7B4 "HASP Plate 01 Page 7 Button 4 State [%s]" (HASP_Plate01_Page7_Button_Group) {mqtt="<[broker:hasp/plate01/state/p[7].b[4]:state:default]"}
@@ -247,42 +109,6 @@ Switch HASP_Plate01_Button_P7B12 "HASP Plate 01 Page 7 Button 12 State [%s]" (HA
 Switch HASP_Plate01_Button_P7B13 "HASP Plate 01 Page 7 Button 13 State [%s]" (HASP_Plate01_Page7_Button_Group) {mqtt="<[broker:hasp/plate01/state/p[7].b[13]:state:default]"}
 Switch HASP_Plate01_Button_P7B14 "HASP Plate 01 Page 7 Button 14 State [%s]" (HASP_Plate01_Page7_Button_Group) {mqtt="<[broker:hasp/plate01/state/p[7].b[14]:state:default]"}
 Switch HASP_Plate01_Button_P7B15 "HASP Plate 01 Page 7 Button 15 State [%s]" (HASP_Plate01_Page7_Button_Group) {mqtt="<[broker:hasp/plate01/state/p[7].b[15]:state:default]"}
-String HASP_Plate01_Button_P7B4_Text "HASP Plate 01 Page 7 Button 4 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[7].b[4].txt:command:*:default]"}
-String HASP_Plate01_Button_P7B5_Text "HASP Plate 01 Page 7 Button 5 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[7].b[5].txt:command:*:default]"}
-String HASP_Plate01_Button_P7B6_Text "HASP Plate 01 Page 7 Button 6 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[7].b[6].txt:command:*:default]"}
-String HASP_Plate01_Button_P7B7_Text "HASP Plate 01 Page 7 Button 7 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[7].b[7].txt:command:*:default]"}
-String HASP_Plate01_Button_P7B8_Text "HASP Plate 01 Page 7 Button 8 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[7].b[8].txt:command:*:default]"}
-String HASP_Plate01_Button_P7B9_Text "HASP Plate 01 Page 7 Button 9 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[7].b[9].txt:command:*:default]"}
-String HASP_Plate01_Button_P7B10_Text "HASP Plate 01 Page 7 Button 10 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[7].b[10].txt:command:*:default]"}
-String HASP_Plate01_Button_P7B11_Text "HASP Plate 01 Page 7 Button 11 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[7].b[11].txt:command:*:default]"}
-String HASP_Plate01_Button_P7B12_Text "HASP Plate 01 Page 7 Button 12 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[7].b[12].txt:command:*:default]"}
-String HASP_Plate01_Button_P7B13_Text "HASP Plate 01 Page 7 Button 13 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[7].b[13].txt:command:*:default]"}
-String HASP_Plate01_Button_P7B14_Text "HASP Plate 01 Page 7 Button 14 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[7].b[14].txt:command:*:default]"}
-String HASP_Plate01_Button_P7B15_Text "HASP Plate 01 Page 7 Button 15 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[7].b[15].txt:command:*:default]"}
-Number HASP_Plate01_Button_P7B4_Bcol "HASP Plate 01 Page 7 Button 4 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[7].b[4].bco:command:*:default]"}
-Number HASP_Plate01_Button_P7B5_Bcol "HASP Plate 01 Page 7 Button 5 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[7].b[5].bco:command:*:default]"}
-Number HASP_Plate01_Button_P7B6_Bcol "HASP Plate 01 Page 7 Button 6 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[7].b[6].bco:command:*:default]"}
-Number HASP_Plate01_Button_P7B7_Bcol "HASP Plate 01 Page 7 Button 7 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[7].b[7].bco:command:*:default]"}
-Number HASP_Plate01_Button_P7B8_Bcol "HASP Plate 01 Page 7 Button 8 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[7].b[8].bco:command:*:default]"}
-Number HASP_Plate01_Button_P7B9_Bcol "HASP Plate 01 Page 7 Button 9 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[7].b[9].bco:command:*:default]"}
-Number HASP_Plate01_Button_P7B10_Bcol "HASP Plate 01 Page 7 Button 10 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[7].b[10].bco:command:*:default]"}
-Number HASP_Plate01_Button_P7B11_Bcol "HASP Plate 01 Page 7 Button 11 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[7].b[11].bco:command:*:default]"}
-Number HASP_Plate01_Button_P7B12_Bcol "HASP Plate 01 Page 7 Button 12 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[7].b[12].bco:command:*:default]"}
-Number HASP_Plate01_Button_P7B13_Bcol "HASP Plate 01 Page 7 Button 13 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[7].b[13].bco:command:*:default]"}
-Number HASP_Plate01_Button_P7B14_Bcol "HASP Plate 01 Page 7 Button 14 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[7].b[14].bco:command:*:default]"}
-Number HASP_Plate01_Button_P7B15_Bcol "HASP Plate 01 Page 7 Button 15 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[7].b[15].bco:command:*:default]"}
-Number HASP_Plate01_Button_P7B4_Font "HASP Plate 01 Page 7 Button 4 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[7].b[4].font:command:*:default]"}
-Number HASP_Plate01_Button_P7B5_Font "HASP Plate 01 Page 7 Button 5 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[7].b[5].font:command:*:default]"}
-Number HASP_Plate01_Button_P7B6_Font "HASP Plate 01 Page 7 Button 6 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[7].b[6].font:command:*:default]"}
-Number HASP_Plate01_Button_P7B7_Font "HASP Plate 01 Page 7 Button 7 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[7].b[7].font:command:*:default]"}
-Number HASP_Plate01_Button_P7B8_Font "HASP Plate 01 Page 7 Button 8 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[7].b[8].font:command:*:default]"}
-Number HASP_Plate01_Button_P7B9_Font "HASP Plate 01 Page 7 Button 9 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[7].b[9].font:command:*:default]"}
-Number HASP_Plate01_Button_P7B10_Font "HASP Plate 01 Page 7 Button 10 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[7].b[10].font:command:*:default]"}
-Number HASP_Plate01_Button_P7B11_Font "HASP Plate 01 Page 7 Button 11 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[7].b[11].font:command:*:default]"}
-Number HASP_Plate01_Button_P7B12_Font "HASP Plate 01 Page 7 Button 12 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[7].b[12].font:command:*:default]"}
-Number HASP_Plate01_Button_P7B13_Font "HASP Plate 01 Page 7 Button 13 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[7].b[13].font:command:*:default]"}
-Number HASP_Plate01_Button_P7B14_Font "HASP Plate 01 Page 7 Button 14 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[7].b[14].font:command:*:default]"}
-Number HASP_Plate01_Button_P7B15_Font "HASP Plate 01 Page 7 Button 15 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[7].b[15].font:command:*:default]"}
 
 /* Page 8 Functional Items */
 Switch HASP_Plate01_Button_P8B4 "HASP Plate 01 Page 8 Button 4 State [%s]" (HASP_Plate01_Page8_Button_Group) {mqtt="<[broker:hasp/plate01/state/p[8].b[4]:state:default]"}
@@ -290,39 +116,17 @@ Switch HASP_Plate01_Button_P8B5 "HASP Plate 01 Page 8 Button 5 State [%s]" (HASP
 Switch HASP_Plate01_Button_P8B6 "HASP Plate 01 Page 8 Button 6 State [%s]" (HASP_Plate01_Page8_Button_Group) {mqtt="<[broker:hasp/plate01/state/p[8].b[6]:state:default]"}
 Switch HASP_Plate01_Button_P8B7 "HASP Plate 01 Page 8 Button 7 State [%s]" (HASP_Plate01_Page8_Button_Group) {mqtt="<[broker:hasp/plate01/state/p[8].b[7]:state:default]"}
 Switch HASP_Plate01_Button_P8B8 "HASP Plate 01 Page 8 Button 8 State [%s]" (HASP_Plate01_Page8_Button_Group) {mqtt="<[broker:hasp/plate01/state/p[8].b[8]:state:default]"}
-String HASP_Plate01_Button_P8B4_Text "HASP Plate 01 Page 8 Button 4 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[8].b[4].txt:command:*:default]"}
-String HASP_Plate01_Button_P8B5_Text "HASP Plate 01 Page 8 Button 5 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[8].b[5].txt:command:*:default]"}
-String HASP_Plate01_Button_P8B6_Text "HASP Plate 01 Page 8 Button 6 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[8].b[6].txt:command:*:default]"}
-String HASP_Plate01_Button_P8B7_Text "HASP Plate 01 Page 8 Button 7 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[8].b[7].txt:command:*:default]"}
-String HASP_Plate01_Button_P8B8_Text "HASP Plate 01 Page 8 Button 8 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[8].b[8].txt:command:*:default]"}
-Number HASP_Plate01_Button_P8B4_Bcol "HASP Plate 01 Page 8 Button 4 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[8].b[4].bco:command:*:default]"}
-Number HASP_Plate01_Button_P8B5_Bcol "HASP Plate 01 Page 8 Button 5 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[8].b[5].bco:command:*:default]"}
-Number HASP_Plate01_Button_P8B6_Bcol "HASP Plate 01 Page 8 Button 6 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[8].b[6].bco:command:*:default]"}
-Number HASP_Plate01_Button_P8B7_Bcol "HASP Plate 01 Page 8 Button 7 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[8].b[7].bco:command:*:default]"}
-Number HASP_Plate01_Button_P8B8_Bcol "HASP Plate 01 Page 8 Button 8 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[8].b[8].bco:command:*:default]"}
-Number HASP_Plate01_Button_P8B4_Font "HASP Plate 01 Page 8 Button 4 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[8].b[4].font:command:*:default]"}
-Number HASP_Plate01_Button_P8B5_Font "HASP Plate 01 Page 8 Button 5 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[8].b[5].font:command:*:default]"}
-Number HASP_Plate01_Button_P8B6_Font "HASP Plate 01 Page 8 Button 6 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[8].b[6].font:command:*:default]"}
-Number HASP_Plate01_Button_P8B7_Font "HASP Plate 01 Page 8 Button 7 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[8].b[7].font:command:*:default]"}
-Number HASP_Plate01_Button_P8B8_Font "HASP Plate 01 Page 8 Button 8 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[8].b[8].font:command:*:default]"}
 Number HASP_Plate01_Dimmer_P8B9 "HASP Plate 01 Page 8 Dimmer 9 State [%d]" (HASP_Plate01_Page8_Dimmer_Group) {mqtt="<[broker:hasp/plate01/state/p[8].b[9].val:state:default]"}
 Number HASP_Plate01_Dimmer_P8B9_Val "HASP Plate 01 Page 8 Dimmer 9 Value" {mqtt=">[broker:hasp/plate01/command/p[8].b[9].val:command:*:default]"}
 
 /* Page 9 Functional Items */
 Switch HASP_Plate01_Button_P9B4 "HASP Plate 01 Page 9 Button 4 State [%s]" (HASP_Plate01_Page9_Button_Group) {mqtt="<[broker:hasp/plate01/state/p[9].b[4]:state:default]"}
 Switch HASP_Plate01_Button_P9B5 "HASP Plate 01 Page 9 Button 5 State [%s]" (HASP_Plate01_Page9_Button_Group) {mqtt="<[broker:hasp/plate01/state/p[9].b[5]:state:default]"}
-String HASP_Plate01_Button_P9B4_Text "HASP Plate 01 Page 9 Button 4 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[9].b[4].txt:command:*:default]"}
-String HASP_Plate01_Button_P9B5_Text "HASP Plate 01 Page 9 Button 5 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[9].b[5].txt:command:*:default]"}
-String HASP_Plate01_Button_P9B6_Text "HASP Plate 01 Page 9 Button 6 Text [%s]" {mqtt=">[broker:hasp/plate01/command/p[9].b[6].txt:command:*:default]"}
-Number HASP_Plate01_Button_P9B4_Bcol "HASP Plate 01 Page 9 Button 4 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[9].b[4].bco:command:*:default]"}
-Number HASP_Plate01_Button_P9B5_Bcol "HASP Plate 01 Page 9 Button 5 Bcol [%d]" {mqtt=">[broker:hasp/plate01/command/p[9].b[5].bco:command:*:default]"}
-Number HASP_Plate01_Button_P9B4_Font "HASP Plate 01 Page 9 Button 4 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[9].b[4].font:command:*:default]"}
-Number HASP_Plate01_Button_P9B5_Font "HASP Plate 01 Page 9 Button 5 Font [%d]" {mqtt=">[broker:hasp/plate01/command/p[9].b[5].font:command:*:default]"}
 
 /* Page Storage Items */
 
 Number HASP_Plate01_Page "HASP Plate 01 Page Select [%d]" (HASP) {mqtt=">[broker:hasp/plate01/command/page:command:*:default]"}
-Number HASP_Plate01_Page_Current "HASP Platte 01 Current Page [%d]" (HASP) {mqtt="<[broker:hasp/plate01/command/page:state:default]"}
+Number HASP_Plate01_Page_Current "HASP Plate 01 Current Page [%d]" (HASP) {mqtt="<[broker:hasp/plate01/command/page:state:default]"}
 
 /* Plate Status Items */
 
@@ -341,6 +145,8 @@ String HASP_Plate01_Plate_Sensor_LCDUpdate "HASP Plate 01 Sensor - LCD Update Av
 Number HASP_Plate01_Plate_Sensor_ESPUptime "HASP Plate 01 Sensor - ESP Uptime [%d secs]" (HASP) {mqtt="<[broker:hasp/plate01/sensor:state:JSONPATH($.espUptime)]"}
 Number HASP_Plate01_Plate_Sensor_SignalStrength "HASP Plate 01 Sensor - Signal Strength [%d dbm]" (HASP) {mqtt="<[broker:hasp/plate01/sensor:state:JSONPATH($.signalStrength)]"}
 String HASP_Plate01_Plate_Sensor_HaspIP "HASP Plate 01 Sensor - HASP IP [%s]" (HASP) {mqtt="<[broker:hasp/plate01/sensor:state:JSONPATH($.haspIP)]"}
+
+Switch HASP_Plate01_Plate_Refresh "HASP Plate 01 Refresh" (HASP) {expire="10s,command=OFF"}
 
 Number HASP_Plate01_Plate_Motion "HASP Plate 01 Motion Status [%d]" (HASP) {mqtt="<[broker:hasp/plate01/motion/state:state:default]"}
 

--- a/contrib/openHAB/HASP-Master.rules
+++ b/contrib/openHAB/HASP-Master.rules
@@ -4,67 +4,67 @@
 
 /* Configuration for the three page selection buttons at the bottom of the page */
 val plate01_pagebutton1page = 1 // Set page # for bottom left button
-val plate01_pagebutton1txt = '"Scenes"' // Set page title for bottom left button
+val plate01_pagebutton1txt = 'Scenes' // Set page title for bottom left button
 val plate01_pagebutton2page = 2 // Set page # for bottom center button
-val plate01_pagebutton2txt = '"Status"' // Set page title for bottom left button
+val plate01_pagebutton2txt = 'Status' // Set page title for bottom left button
 val plate01_pagebutton3page = 6 // Set page # for bottom right button
-val plate01_pagebutton3txt = '"HVAC"' // Set page title for bottom left button
+val plate01_pagebutton3txt = 'HVAC' // Set page title for bottom left button
 
 /* Configuration for page 1 (Scenes) */
-val plate01_page1button4txt = '"Morning"'
-val plate01_page1button5txt = '"Evening"'
-val plate01_page1button6txt = '"Night"'
-val plate01_page1button7txt = '"Bedtime"'
+val plate01_page1button4txt = 'Morning'
+val plate01_page1button5txt = 'Evening'
+val plate01_page1button6txt = 'Night'
+val plate01_page1button7txt = 'Bedtime'
 val plate01_page1button4font = 2
 val plate01_page1button5font = 2
 val plate01_page1button6font = 2
 val plate01_page1button7font = 2
 
 /* Configuration for page 2 (Status) */
-val plate01_page2button4txt = '"Line 1"'
-val plate01_page2button5txt = '"Line 2"'
-val plate01_page2button6txt = '"Line 3"'
-val plate01_page2button7txt = '"Line 4"'
+val plate01_page2button4txt = 'Line 1'
+val plate01_page2button5txt = 'Line 2'
+val plate01_page2button6txt = 'Line 3'
+val plate01_page2button7txt = 'Line 4'
 val plate01_page2button4font = 2
 val plate01_page2button5font = 2
 val plate01_page2button6font = 2
 val plate01_page2button7font = 1
 
 /* Configuration for page 3 (Page 3) */
-val plate01_page3button4txt = '"P3 B4 Text"'
-val plate01_page3button5txt = '"P3 B5 Text"'
-val plate01_page3button6txt = '"P3 B6 Text"'
-val plate01_page3button7txt = '"P3 B7 Text"'
+val plate01_page3button4txt = 'P3 B4 Text'
+val plate01_page3button5txt = 'P3 B5 Text'
+val plate01_page3button6txt = 'P3 B6 Text'
+val plate01_page3button7txt = 'P3 B7 Text'
 val plate01_page3button4font = 1
 val plate01_page3button5font = 1
 val plate01_page3button6font = 1
 val plate01_page3button7font = 1
 
 /* Configuration for page 4 (Page 4) */
-val plate01_page4button4txt = '"P4 B4 Light"'
-val plate01_page4button5txt = '"P4 B5 Light"'
-val plate01_page4button6txt = '"P4 B6 Light"'
+val plate01_page4button4txt = 'P4 B4 Light'
+val plate01_page4button5txt = 'P4 B5 Light'
+val plate01_page4button6txt = 'P4 B6 Light'
 val plate01_page4button4font = 1
 val plate01_page4button5font = 1
 val plate01_page4button6font = 1
 
 /* Configuration for page 5 (Page 5) */
-val plate01_page5button4txt = '"P5 B4 Light"'
-val plate01_page5button5txt = '"P5 B5 Light"'
-val plate01_page5button6txt = '"P5 B6 Light"'
+val plate01_page5button4txt = 'P5 B4 Light'
+val plate01_page5button5txt = 'P5 B5 Light'
+val plate01_page5button6txt = 'P5 B6 Light'
 val plate01_page5button4font = 1
 val plate01_page5button5font = 1
 val plate01_page5button6font = 1
 
 /* Configuration for page 6 (HVAC) */
-val plate01_page6button4txt = '"P6 B4"'
-val plate01_page6button5txt = '"P6 B5"'
-val plate01_page6button6txt = '"P6 B6"'
-val plate01_page6button7txt = '"P6 B7"'
-val plate01_page6button8txt = '"P6 B8"'
-val plate01_page6button9txt = '"P6 B9"'
-val plate01_page6button10txt = '"P6 B10"'
-val plate01_page6button11txt = '"P6 B11"'
+val plate01_page6button4txt = 'P6 B4'
+val plate01_page6button5txt = 'P6 B5'
+val plate01_page6button6txt = 'P6 B6'
+val plate01_page6button7txt = 'P6 B7'
+val plate01_page6button8txt = 'P6 B8'
+val plate01_page6button9txt = 'P6 B9'
+val plate01_page6button10txt = 'P6 B10'
+val plate01_page6button11txt = 'P6 B11'
 val plate01_page6button4font = 1
 val plate01_page6button5font = 1
 val plate01_page6button6font = 1
@@ -75,18 +75,18 @@ val plate01_page6button10font = 1
 val plate01_page6button11font = 1
 
 /* Configuration for page 7 (Page 7) */
-val plate01_page7button4txt = '"1"'
-val plate01_page7button5txt = '"2"'
-val plate01_page7button6txt = '"3"'
-val plate01_page7button7txt = '"4"'
-val plate01_page7button8txt = '"5"'
-val plate01_page7button9txt = '"6"'
-val plate01_page7button10txt = '"7"'
-val plate01_page7button11txt = '"8"'
-val plate01_page7button12txt = '"9"'
-val plate01_page7button13txt = '"*"'
-val plate01_page7button14txt = '"0"'
-val plate01_page7button15txt = '"#"'
+val plate01_page7button4txt = '1'
+val plate01_page7button5txt = '2'
+val plate01_page7button6txt = '3'
+val plate01_page7button7txt = '4'
+val plate01_page7button8txt = '5'
+val plate01_page7button9txt = '6'
+val plate01_page7button10txt = '7'
+val plate01_page7button11txt = '8'
+val plate01_page7button12txt = '9'
+val plate01_page7button13txt = '*'
+val plate01_page7button14txt = '0'
+val plate01_page7button15txt = '#'
 val plate01_page7button4font = 3
 val plate01_page7button5font = 3
 val plate01_page7button6font = 3
@@ -101,11 +101,11 @@ val plate01_page7button14font = 3
 val plate01_page7button15font = 3
 
 /* Configuration for page 8 (Page 8) */
-val plate01_page8button4txt = '"P8 B4"'
-val plate01_page8button5txt = '"P8 B5"'
-val plate01_page8button6txt = '"P8B6"'
-val plate01_page8button7txt = '"P8B7"'
-val plate01_page8button8txt = '"P8B8"'
+val plate01_page8button4txt = 'P8 B4'
+val plate01_page8button5txt = 'P8 B5'
+val plate01_page8button6txt = 'P8B6'
+val plate01_page8button7txt = 'P8B7'
+val plate01_page8button8txt = 'P8B8'
 val plate01_page8button4font = 1
 val plate01_page8button5font = 1
 val plate01_page8button6font = 1
@@ -113,8 +113,8 @@ val plate01_page8button7font = 1
 val plate01_page8button8font = 1
 
 /* Configuration for page 9 (Page 9) */
-val plate01_page9button4txt = '"P9 B4"'
-val plate01_page9button5txt = '"P9 B5"'
+val plate01_page9button4txt = 'P9 B4'
+val plate01_page9button5txt = 'P9 B5'
 val plate01_page9button4font = 2
 val plate01_page9button5font = 2
 
@@ -594,126 +594,165 @@ end
 /* Restore saved page and rebuild config on reconnect */
 rule "HASP Master Restore page on connect"
 when
-    Item HASP_Plate01_Plate_Sensor_Status changed to "available"
+    Item HASP_Plate01_Plate_Sensor_Status changed to "available" or
+    Item HASP_Plate01_Plate_Refresh received command ON
 then
   
     HASP_Plate01_Page.sendCommand(HASP_Plate01_Page_Current.state as Number) // Send HASP to previous page
 
-    HASP_Plate01_Button1_Bcol_Group.sendCommand("25388") // Initialize page buttons with gray color
-    HASP_Plate01_Button2_Bcol_Group.sendCommand("25388")
-    HASP_Plate01_Button3_Bcol_Group.sendCommand("25388")
-    HASP_Plate01_Button1_Text_Group.sendCommand(plate01_pagebutton1txt) // Set bottom page buttons text
-    HASP_Plate01_Button2_Text_Group.sendCommand(plate01_pagebutton2txt)
-    HASP_Plate01_Button3_Text_Group.sendCommand(plate01_pagebutton3txt)
+    var jsonString = '["p[1].b[1].bco=25388", ' +   //Initialize bottom page buttons with gray color
+                    '"p[1].b[2].bco=25388", ' +
+                    '"p[1].b[3].bco=25388", ' +
+                    '"p[2].b[1].bco=25388", ' +
+                    '"p[2].b[2].bco=25388", ' +
+                    '"p[2].b[3].bco=25388", ' +
+                    '"p[3].b[1].bco=25388", ' +
+                    '"p[3].b[2].bco=25388", ' +
+                    '"p[3].b[3].bco=25388", ' +
+                    '"p[4].b[1].bco=25388", ' +
+                    '"p[4].b[2].bco=25388", ' +
+                    '"p[4].b[3].bco=25388", ' +
+                    '"p[5].b[1].bco=25388", ' +
+                    '"p[5].b[2].bco=25388", ' +
+                    '"p[5].b[3].bco=25388", ' +
+                    '"p[6].b[1].bco=25388", ' +
+                    '"p[6].b[2].bco=25388", ' +
+                    '"p[6].b[3].bco=25388", ' +
+                    '"p[7].b[1].bco=25388", ' +
+                    '"p[7].b[2].bco=25388", ' +
+                    '"p[7].b[3].bco=25388", ' +
+                    '"p[8].b[1].bco=25388", ' +
+                    '"p[8].b[2].bco=25388", ' +
+                    '"p[8].b[3].bco=25388", ' +
+                    '"p[9].b[1].bco=25388", ' +
+                    '"p[9].b[2].bco=25388", ' +
+                    '"p[9].b[3].bco=25388", ' +
+                    '"p[1].b[1].txt=\\"' + plate01_pagebutton1txt + '\\"", ' +  //Initialize bottom page button text
+                    '"p[1].b[2].txt=\\"' + plate01_pagebutton2txt + '\\"", ' +
+                    '"p[1].b[3].txt=\\"' + plate01_pagebutton3txt + '\\"", ' +
+                    '"p[2].b[1].txt=\\"' + plate01_pagebutton1txt + '\\"", ' +
+                    '"p[2].b[2].txt=\\"' + plate01_pagebutton2txt + '\\"", ' +
+                    '"p[2].b[3].txt=\\"' + plate01_pagebutton3txt + '\\"", ' +
+                    '"p[3].b[1].txt=\\"' + plate01_pagebutton1txt + '\\"", ' +
+                    '"p[3].b[2].txt=\\"' + plate01_pagebutton2txt + '\\"", ' +
+                    '"p[3].b[3].txt=\\"' + plate01_pagebutton3txt + '\\"", ' +
+                    '"p[4].b[1].txt=\\"' + plate01_pagebutton1txt + '\\"", ' +
+                    '"p[4].b[2].txt=\\"' + plate01_pagebutton2txt + '\\"", ' +
+                    '"p[4].b[3].txt=\\"' + plate01_pagebutton3txt + '\\"", ' +
+                    '"p[5].b[1].txt=\\"' + plate01_pagebutton1txt + '\\"", ' +
+                    '"p[5].b[2].txt=\\"' + plate01_pagebutton2txt + '\\"", ' +
+                    '"p[5].b[3].txt=\\"' + plate01_pagebutton3txt + '\\"", ' +
+                    '"p[6].b[1].txt=\\"' + plate01_pagebutton1txt + '\\"", ' +
+                    '"p[6].b[2].txt=\\"' + plate01_pagebutton2txt + '\\"", ' +
+                    '"p[6].b[3].txt=\\"' + plate01_pagebutton3txt + '\\"", ' +
+                    '"p[7].b[1].txt=\\"' + plate01_pagebutton1txt + '\\"", ' +
+                    '"p[7].b[2].txt=\\"' + plate01_pagebutton2txt + '\\"", ' +
+                    '"p[7].b[3].txt=\\"' + plate01_pagebutton3txt + '\\"", ' +
+                    '"p[8].b[1].txt=\\"' + plate01_pagebutton1txt + '\\"", ' +
+                    '"p[8].b[2].txt=\\"' + plate01_pagebutton2txt + '\\"", ' +
+                    '"p[8].b[3].txt=\\"' + plate01_pagebutton3txt + '\\"", ' +
+                    '"p[9].b[1].txt=\\"' + plate01_pagebutton1txt + '\\"", ' +
+                    '"p[9].b[2].txt=\\"' + plate01_pagebutton2txt + '\\"", ' +
+                    '"p[9].b[3].txt=\\"' + plate01_pagebutton3txt + '\\""]'                  
 
-    /* Build Page 1 */
-    HASP_Plate01_Button_P1B4_Text.sendCommand(plate01_page1button4txt)
-    HASP_Plate01_Button_P1B5_Text.sendCommand(plate01_page1button5txt)
-    HASP_Plate01_Button_P1B6_Text.sendCommand(plate01_page1button6txt)
-    HASP_Plate01_Button_P1B7_Text.sendCommand(plate01_page1button7txt)
-    HASP_Plate01_Button_P1B4_Font.sendCommand(plate01_page1button4font)
-    HASP_Plate01_Button_P1B5_Font.sendCommand(plate01_page1button5font)
-    HASP_Plate01_Button_P1B6_Font.sendCommand(plate01_page1button6font)
-    HASP_Plate01_Button_P1B7_Font.sendCommand(plate01_page1button7font)
+    HASP_Plate01_Plate_Command_JSON.sendCommand(jsonString)
 
-    /* Build Page 2 */
-    HASP_Plate01_Button_P2B4_Text.sendCommand(plate01_page2button4txt)
-    HASP_Plate01_Button_P2B5_Text.sendCommand(plate01_page2button5txt)
-    HASP_Plate01_Button_P2B6_Text.sendCommand(plate01_page2button6txt)
-    HASP_Plate01_Button_P2B7_Text.sendCommand(plate01_page2button7txt)
-    HASP_Plate01_Button_P2B4_Font.sendCommand(plate01_page2button4font)
-    HASP_Plate01_Button_P2B5_Font.sendCommand(plate01_page2button5font)
-    HASP_Plate01_Button_P2B6_Font.sendCommand(plate01_page2button6font)
-    HASP_Plate01_Button_P2B7_Font.sendCommand(plate01_page2button7font)
+    jsonString = '["p[1].b[4].txt=\\"' + plate01_page1button4txt + '\\"", ' +    // Update button texts for all pages
+                     '"p[1].b[5].txt=\\"' + plate01_page1button5txt + '\\"", ' +
+                     '"p[1].b[6].txt=\\"' + plate01_page1button6txt + '\\"", ' +
+                     '"p[1].b[7].txt=\\"' + plate01_page1button7txt + '\\"", ' +
+                     '"p[2].b[4].txt=\\"' + plate01_page2button4txt + '\\"", ' +
+                     '"p[2].b[5].txt=\\"' + plate01_page2button5txt + '\\"", ' +
+                     '"p[2].b[6].txt=\\"' + plate01_page2button6txt + '\\"", ' +
+                     '"p[2].b[7].txt=\\"' + plate01_page2button7txt + '\\"", ' +
+                     '"p[3].b[4].txt=\\"' + plate01_page3button4txt + '\\"", ' +
+                     '"p[3].b[5].txt=\\"' + plate01_page3button5txt + '\\"", ' +
+                     '"p[3].b[6].txt=\\"' + plate01_page3button6txt + '\\"", ' +
+                     '"p[3].b[7].txt=\\"' + plate01_page3button7txt + '\\"", ' +                                                                                                                                                   
+                     '"p[4].b[4].txt=\\"' + plate01_page4button4txt + '\\"", ' +
+                     '"p[4].b[5].txt=\\"' + plate01_page4button5txt + '\\"", ' +
+                     '"p[4].b[6].txt=\\"' + plate01_page4button6txt + '\\"", ' +
+                     '"p[5].b[4].txt=\\"' + plate01_page5button4txt + '\\"", ' +
+                     '"p[5].b[5].txt=\\"' + plate01_page5button5txt + '\\"", ' +
+                     '"p[5].b[6].txt=\\"' + plate01_page5button6txt + '\\"", ' +   
+                     '"p[6].b[4].txt=\\"' + plate01_page6button4txt + '\\"", ' +
+                     '"p[6].b[5].txt=\\"' + plate01_page6button5txt + '\\"", ' +
+                     '"p[6].b[6].txt=\\"' + plate01_page6button6txt + '\\"", ' +
+                     '"p[6].b[7].txt=\\"' + plate01_page6button7txt + '\\"", ' +
+                     '"p[6].b[8].txt=\\"' + plate01_page6button8txt + '\\"", ' +
+                     '"p[6].b[9].txt=\\"' + plate01_page6button9txt + '\\"", ' +
+                     '"p[6].b[10].txt=\\"' + plate01_page6button10txt + '\\"", ' +
+                     '"p[6].b[11].txt=\\"' + plate01_page6button11txt + '\\"", ' +
+                     '"p[7].b[4].txt=\\"' + plate01_page7button4txt + '\\"", ' +
+                     '"p[7].b[5].txt=\\"' + plate01_page7button5txt + '\\"", ' +
+                     '"p[7].b[6].txt=\\"' + plate01_page7button6txt + '\\"", ' +
+                     '"p[7].b[7].txt=\\"' + plate01_page7button7txt + '\\"", ' +
+                     '"p[7].b[8].txt=\\"' + plate01_page7button8txt + '\\"", ' +
+                     '"p[7].b[9].txt=\\"' + plate01_page7button9txt + '\\"", ' +
+                     '"p[7].b[10].txt=\\"' + plate01_page7button10txt + '\\"", ' +
+                     '"p[7].b[11].txt=\\"' + plate01_page7button11txt + '\\"", ' +
+                     '"p[7].b[12].txt=\\"' + plate01_page7button12txt + '\\"", ' +
+                     '"p[7].b[13].txt=\\"' + plate01_page7button13txt + '\\"", ' +
+                     '"p[7].b[14].txt=\\"' + plate01_page7button14txt + '\\"", ' +
+                     '"p[7].b[15].txt=\\"' + plate01_page7button15txt + '\\"", ' +
+                     '"p[8].b[4].txt=\\"' + plate01_page8button4txt + '\\"", ' +
+                     '"p[8].b[5].txt=\\"' + plate01_page8button5txt + '\\"", ' +
+                     '"p[8].b[6].txt=\\"' + plate01_page8button6txt + '\\"", ' +
+                     '"p[8].b[7].txt=\\"' + plate01_page8button7txt + '\\"", ' +
+                     '"p[8].b[8].txt=\\"' + plate01_page8button8txt + '\\"", ' + 
+                     '"p[9].b[4].txt=\\"' + plate01_page9button4txt + '\\"", ' +
+                     '"p[9].b[5].txt=\\"' + plate01_page9button5txt + '\\""]'
 
-    /* Build Page 3 */
-    HASP_Plate01_Button_P3B4_Text.sendCommand(plate01_page3button4txt)
-    HASP_Plate01_Button_P3B5_Text.sendCommand(plate01_page3button5txt)
-    HASP_Plate01_Button_P3B6_Text.sendCommand(plate01_page3button6txt)
-    HASP_Plate01_Button_P3B7_Text.sendCommand(plate01_page3button7txt)
-    HASP_Plate01_Button_P3B4_Font.sendCommand(plate01_page3button4font)
-    HASP_Plate01_Button_P3B5_Font.sendCommand(plate01_page3button5font)
-    HASP_Plate01_Button_P3B6_Font.sendCommand(plate01_page3button6font)
-    HASP_Plate01_Button_P3B7_Font.sendCommand(plate01_page3button7font)
+    HASP_Plate01_Plate_Command_JSON.sendCommand(jsonString)
 
-    /* Build Page 4 */
-    HASP_Plate01_Button_P4B4_Text.sendCommand(plate01_page4button4txt)
-    HASP_Plate01_Button_P4B5_Text.sendCommand(plate01_page4button5txt)
-    HASP_Plate01_Button_P4B6_Text.sendCommand(plate01_page4button6txt)
-    HASP_Plate01_Button_P4B4_Font.sendCommand(plate01_page4button4font)
-    HASP_Plate01_Button_P4B5_Font.sendCommand(plate01_page4button5font)
-    HASP_Plate01_Button_P4B6_Font.sendCommand(plate01_page4button6font)
-    
-    /* Build Page 5 */
-    HASP_Plate01_Button_P5B4_Text.sendCommand(plate01_page5button4txt)
-    HASP_Plate01_Button_P5B5_Text.sendCommand(plate01_page5button5txt)
-    HASP_Plate01_Button_P5B6_Text.sendCommand(plate01_page5button6txt)
-    HASP_Plate01_Button_P5B4_Font.sendCommand(plate01_page5button4font)
-    HASP_Plate01_Button_P5B5_Font.sendCommand(plate01_page5button5font)
-    HASP_Plate01_Button_P5B6_Font.sendCommand(plate01_page5button6font)
+    jsonString = '["p[1].b[4].font=' + plate01_page1button4font + '", ' +    // Update font sizes for all pages
+                     '"p[1].b[5].font=' + plate01_page1button5font + '", ' +
+                     '"p[1].b[6].font=' + plate01_page1button6font + '", ' +
+                     '"p[1].b[7].font=' + plate01_page1button7font + '", ' +
+                     '"p[2].b[4].font=' + plate01_page2button4font + '", ' +
+                     '"p[2].b[5].font=' + plate01_page2button5font + '", ' +
+                     '"p[2].b[6].font=' + plate01_page2button6font + '", ' +
+                     '"p[2].b[7].font=' + plate01_page2button7font + '", ' +
+                     '"p[3].b[4].font=' + plate01_page3button4font + '", ' +
+                     '"p[3].b[5].font=' + plate01_page3button5font + '", ' +
+                     '"p[3].b[6].font=' + plate01_page3button6font + '", ' +
+                     '"p[3].b[7].font=' + plate01_page3button7font + '", ' +                                                                                                                                                   
+                     '"p[4].b[4].font=' + plate01_page4button4font + '", ' +
+                     '"p[4].b[5].font=' + plate01_page4button5font + '", ' +
+                     '"p[4].b[6].font=' + plate01_page4button6font + '", ' +
+                     '"p[5].b[4].font=' + plate01_page5button4font + '", ' +
+                     '"p[5].b[5].font=' + plate01_page5button5font + '", ' +
+                     '"p[5].b[6].font=' + plate01_page5button6font + '", ' +   
+                     '"p[6].b[4].font=' + plate01_page6button4font + '", ' +
+                     '"p[6].b[5].font=' + plate01_page6button5font + '", ' +
+                     '"p[6].b[6].font=' + plate01_page6button6font + '", ' +
+                     '"p[6].b[7].font=' + plate01_page6button7font + '", ' +
+                     '"p[6].b[8].font=' + plate01_page6button8font + '", ' +
+                     '"p[6].b[9].font=' + plate01_page6button9font + '", ' +
+                     '"p[6].b[10].font=' + plate01_page6button10font + '", ' +
+                     '"p[6].b[11].font=' + plate01_page6button11font + '", ' +
+                     '"p[7].b[4].font=' + plate01_page7button4font + '", ' +
+                     '"p[7].b[5].font=' + plate01_page7button5font + '", ' +
+                     '"p[7].b[6].font=' + plate01_page7button6font + '", ' +
+                     '"p[7].b[7].font=' + plate01_page7button7font + '", ' +
+                     '"p[7].b[8].font=' + plate01_page7button8font + '", ' +
+                     '"p[7].b[9].font=' + plate01_page7button9font + '", ' +
+                     '"p[7].b[10].font=' + plate01_page7button10font + '", ' +
+                     '"p[7].b[11].font=' + plate01_page7button11font + '", ' +
+                     '"p[7].b[12].font=' + plate01_page7button12font + '", ' +
+                     '"p[7].b[13].font=' + plate01_page7button13font + '", ' +
+                     '"p[7].b[14].font=' + plate01_page7button14font + '", ' +
+                     '"p[7].b[15].font=' + plate01_page7button15font + '", ' +
+                     '"p[8].b[4].font=' + plate01_page8button4font + '", ' +
+                     '"p[8].b[5].font=' + plate01_page8button5font + '", ' +
+                     '"p[8].b[6].font=' + plate01_page8button6font + '", ' +
+                     '"p[8].b[7].font=' + plate01_page8button7font + '", ' +
+                     '"p[8].b[8].font=' + plate01_page8button8font + '", ' + 
+                     '"p[9].b[4].font=' + plate01_page9button4font + '", ' +
+                     '"p[9].b[5].font=' + plate01_page9button5font + '"]'
 
-    /* Build Page 6 */
-    HASP_Plate01_Button_P6B4_Text.sendCommand(plate01_page6button4txt)
-    HASP_Plate01_Button_P6B5_Text.sendCommand(plate01_page6button5txt)
-    HASP_Plate01_Button_P6B6_Text.sendCommand(plate01_page6button6txt)
-    HASP_Plate01_Button_P6B7_Text.sendCommand(plate01_page6button7txt)
-    HASP_Plate01_Button_P6B8_Text.sendCommand(plate01_page6button8txt)
-    HASP_Plate01_Button_P6B9_Text.sendCommand(plate01_page6button9txt)
-    HASP_Plate01_Button_P6B10_Text.sendCommand(plate01_page6button10txt)
-    HASP_Plate01_Button_P6B11_Text.sendCommand(plate01_page6button11txt)
-    HASP_Plate01_Button_P6B4_Font.sendCommand(plate01_page6button4font)
-    HASP_Plate01_Button_P6B5_Font.sendCommand(plate01_page6button5font)
-    HASP_Plate01_Button_P6B6_Font.sendCommand(plate01_page6button6font)
-    HASP_Plate01_Button_P6B7_Font.sendCommand(plate01_page6button7font)
-    HASP_Plate01_Button_P6B8_Font.sendCommand(plate01_page6button8font)
-    HASP_Plate01_Button_P6B9_Font.sendCommand(plate01_page6button9font)
-    HASP_Plate01_Button_P6B10_Font.sendCommand(plate01_page6button10font)
-    HASP_Plate01_Button_P6B11_Font.sendCommand(plate01_page6button11font)
-    
-    /* Build Page 7 */
-    HASP_Plate01_Button_P7B4_Text.sendCommand(plate01_page7button4txt)
-    HASP_Plate01_Button_P7B5_Text.sendCommand(plate01_page7button5txt)
-    HASP_Plate01_Button_P7B6_Text.sendCommand(plate01_page7button6txt)
-    HASP_Plate01_Button_P7B7_Text.sendCommand(plate01_page7button7txt)
-    HASP_Plate01_Button_P7B8_Text.sendCommand(plate01_page7button8txt)
-    HASP_Plate01_Button_P7B9_Text.sendCommand(plate01_page7button9txt)
-    HASP_Plate01_Button_P7B10_Text.sendCommand(plate01_page7button10txt)
-    HASP_Plate01_Button_P7B11_Text.sendCommand(plate01_page7button11txt)
-    HASP_Plate01_Button_P7B12_Text.sendCommand(plate01_page7button12txt)
-    HASP_Plate01_Button_P7B13_Text.sendCommand(plate01_page7button13txt)
-    HASP_Plate01_Button_P7B14_Text.sendCommand(plate01_page7button14txt)
-    HASP_Plate01_Button_P7B15_Text.sendCommand(plate01_page7button15txt)
-    HASP_Plate01_Button_P7B4_Font.sendCommand(plate01_page7button4font)
-    HASP_Plate01_Button_P7B5_Font.sendCommand(plate01_page7button5font)
-    HASP_Plate01_Button_P7B6_Font.sendCommand(plate01_page7button6font)
-    HASP_Plate01_Button_P7B7_Font.sendCommand(plate01_page7button7font)
-    HASP_Plate01_Button_P7B8_Font.sendCommand(plate01_page7button8font)
-    HASP_Plate01_Button_P7B9_Font.sendCommand(plate01_page7button9font)
-    HASP_Plate01_Button_P7B10_Font.sendCommand(plate01_page7button10font)
-    HASP_Plate01_Button_P7B11_Font.sendCommand(plate01_page7button11font)
-    HASP_Plate01_Button_P7B12_Font.sendCommand(plate01_page7button12font)
-    HASP_Plate01_Button_P7B13_Font.sendCommand(plate01_page7button13font)
-    HASP_Plate01_Button_P7B14_Font.sendCommand(plate01_page7button14font)
-    HASP_Plate01_Button_P7B15_Font.sendCommand(plate01_page7button15font)
-    
-    /* Build Page 8 */
-    HASP_Plate01_Button_P8B4_Text.sendCommand(plate01_page8button4txt)
-    HASP_Plate01_Button_P8B5_Text.sendCommand(plate01_page8button5txt)
-    HASP_Plate01_Button_P8B6_Text.sendCommand(plate01_page8button6txt)
-    HASP_Plate01_Button_P8B7_Text.sendCommand(plate01_page8button7txt)
-    HASP_Plate01_Button_P8B8_Text.sendCommand(plate01_page8button8txt)
-    HASP_Plate01_Button_P8B4_Font.sendCommand(plate01_page8button4font)
-    HASP_Plate01_Button_P8B5_Font.sendCommand(plate01_page8button5font)
-    HASP_Plate01_Button_P8B6_Font.sendCommand(plate01_page8button6font)
-    HASP_Plate01_Button_P8B7_Font.sendCommand(plate01_page8button7font)
-    HASP_Plate01_Button_P8B8_Font.sendCommand(plate01_page8button8font)
-    
-    /* Build Page 9 */
-    HASP_Plate01_Button_P9B4_Text.sendCommand(plate01_page9button4txt)
-    HASP_Plate01_Button_P9B5_Text.sendCommand(plate01_page9button5txt)
-    HASP_Plate01_Button_P9B4_Font.sendCommand(plate01_page9button4font)
-    HASP_Plate01_Button_P9B5_Font.sendCommand(plate01_page9button5font)
-    
+    HASP_Plate01_Plate_Command_JSON.sendCommand(jsonString)
+   
 end
 
 /* Select hasp_plate01_page in response to page button 1 */
@@ -747,23 +786,30 @@ end
 rule "HASP Master set page button colors on page change"
 when
     Item HASP_Plate01_Page_Current received update 
-then
-    var jsonString = '["p['+ (HASP_Plate01_Page_Current.state.toString) + '].b[1].bco=25388", ' +
-                        '"p['+ (HASP_Plate01_Page_Current.state.toString) + '].b[2].bco=25388", ' +
-                        '"p['+ (HASP_Plate01_Page_Current.state.toString) + '].b[3].bco=25388", '
+then    
+    if (HASP_Plate01_Page_Current.state != 0)
+    {
+        var jsonString = '["p['+ (HASP_Plate01_Page_Current.state.toString) + '].b[1].bco=25388", ' +
+                            '"p['+ (HASP_Plate01_Page_Current.state.toString) + '].b[2].bco=25388", ' +
+                            '"p['+ (HASP_Plate01_Page_Current.state.toString) + '].b[3].bco=25388"'
 
-    if (HASP_Plate01_Page_Current.state == plate01_pagebutton1page)
-    {
-            jsonString = jsonString + '"p['+ (HASP_Plate01_Page_Current.state.toString) + '].b[1].bco=65535"]'
-    }
-    else if (HASP_Plate01_Page_Current.state == plate01_pagebutton2page)
-    {
-            jsonString = jsonString + '"p['+ (HASP_Plate01_Page_Current.state.toString) + '].b[2].bco=65535"]'
-    }
-    else if (HASP_Plate01_Page_Current.state == plate01_pagebutton3page)
-    {
-            jsonString = jsonString + '"p['+ (HASP_Plate01_Page_Current.state.toString) + '].b[3].bco=65535"]'
-    }
+        if (HASP_Plate01_Page_Current.state == plate01_pagebutton1page)
+        {
+                jsonString = jsonString + ', "p['+ (HASP_Plate01_Page_Current.state.toString) + '].b[1].bco=65535"]'
+        }
+        else if (HASP_Plate01_Page_Current.state == plate01_pagebutton2page)
+        {
+                jsonString = jsonString + ', "p['+ (HASP_Plate01_Page_Current.state.toString) + '].b[2].bco=65535"]'
+        }
+        else if (HASP_Plate01_Page_Current.state == plate01_pagebutton3page)
+        {
+                jsonString = jsonString + ', "p['+ (HASP_Plate01_Page_Current.state.toString) + '].b[3].bco=65535"]'
+        }
+        else
+        {
+                jsonString = jsonString + ']'
+        }
 
-    HASP_Plate01_Plate_Command_JSON.sendCommand(jsonString)
+        HASP_Plate01_Plate_Command_JSON.sendCommand(jsonString)
+    }
 end

--- a/contrib/openHAB/HASP.sitemap
+++ b/contrib/openHAB/HASP.sitemap
@@ -14,6 +14,7 @@ sitemap hasp label="HASP"
         Text item=HASP_Plate01_Plate_Sensor_ESPUptime
         Text item=HASP_Plate01_Plate_Sensor_SignalStrength
         Text item=HASP_Plate01_Plate_Sensor_HaspIP
+	Switch item=HASP_Plate01_Plate_Refresh
         Frame{
             Switch item=HASP_Plate01_Light_Power
             Text item=HASP_Plate01_Light_Status


### PR DESCRIPTION
-Rewrote all openHAB->HASP rules to use the JSON command topic for formatting like button text and font size.
-Removed all individual items for txt/font/bco topics (cut # of items down by half)
-Added "Refresh" button to the sitemap, to allow resending all formatting messages manually