### PR TITLE
Fix for auto firmware upgrades - sensor name

### DIFF
--- a/Home_Assistant/hasp-examples/plate01/hasp_plate01_00_autofirmwareupdate.yaml
+++ b/Home_Assistant/hasp-examples/plate01/hasp_plate01_00_autofirmwareupdate.yaml
@@ -7,7 +7,7 @@ automation:
         at: '3:00:00'
     condition:
     - condition: template
-      value_template: '{{ states.sensor.plate01_status.attributes.updateESPAvailable == true }}'
+      value_template: '{{ states.sensor.plate01_status.attributes.updateEspAvailable == true }}'
     - condition: state
       entity_id: 'binary_sensor.plate01_connected'
       state: 'on'

--- a/Home_Assistant/packages/plate01/hasp_plate01_00_components.yaml
+++ b/Home_Assistant/packages/plate01/hasp_plate01_00_components.yaml
@@ -46,7 +46,7 @@ binary_sensor:
 
 sensor:
   - platform: mqtt
-    name: plate01 Sensor
+    name: plate01 Status
     state_topic: "hasp/plate01/status"
     availability_topic: "hasp/plate01/status"
     payload_available: "ON"


### PR DESCRIPTION
I noticed my auto firmware upgrades weren't triggering and it's because the auto firmware upgrade automation was looking for a sensor named "myhasp_status" which doesn't exist.

Hoping this is the right fix since it seems redundant to have "sensor" in the sensor name and I'm thinking it was a typo. The alternative could be to change the firmware automation to use the right name.

Let me know and I'm happy to change it!